### PR TITLE
fix: dependency archive for pyspark

### DIFF
--- a/bin/build_aws_package.sh
+++ b/bin/build_aws_package.sh
@@ -374,8 +374,8 @@ aws s3 cp "$SCRIPT_DIR/whl_pkg/"*.whl "s3://$S3_BUCKET/emr-data-processing/src0/
 
 # Upload dependencies
 echo "Uploading dependencies..."
-aws s3 cp "$SCRIPT_DIR/dependencies/dependencies.zip" "s3://$S3_BUCKET/pkg/dependencies/"
-aws s3 cp "$SCRIPT_DIR/dependencies/dependencies.zip" "s3://$S3_BUCKET/emr-data-processing/src0/dependencies/dependencies.zip"
+aws s3 cp "$SCRIPT_DIR/dependencies/environment.tar.gz" "s3://$S3_BUCKET/pkg/dependencies/"
+aws s3 cp "$SCRIPT_DIR/dependencies/environment.tar.gz" "s3://$S3_BUCKET/emr-data-processing/src0/dependencies/environment.tar.gz"
 
 # Upload entry script
 echo "Uploading entry script..."
@@ -395,7 +395,7 @@ echo "Upload completed successfully!"
 echo ""
 echo "Files uploaded to:"
 echo "  - s3://$S3_BUCKET/pkg/whl_pkg/"
-echo "  - s3://$S3_BUCKET/pkg/dependencies/"
+echo "  - s3://$S3_BUCKET/pkg/dependencies/environment.tar.gz"
 echo "  - s3://$S3_BUCKET/pkg/entry_script/"
 if [ -d "$SCRIPT_DIR/jars" ] && [ "$(ls -A $SCRIPT_DIR/jars)" ]; then
     echo "  - s3://$S3_BUCKET/pkg/jars/"


### PR DESCRIPTION


## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description


## Why

PR #56 (5d918f5) did a bunch of work moving the dependency build from a plain zip to a venv-pack archive (environment.tar.gz) to support native extensions like pydantic_core. This new pack was referenced it lots of places but looks like the upload script and DAGs were not updated to match, so the new archive was never uploaded to S3 and workers continued loading the stale dependencies.zip via --py-files (which cannot load native extensions).

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- [Ticket Link](https://github.com/digital-land/airflow-dags/issues/76)
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?
