### PR TITLE
feat: change the filters on assemble-tasks pipeline

### DIFF
--- a/src/jobs/pipeline.py
+++ b/src/jobs/pipeline.py
@@ -766,8 +766,9 @@ class TaskPipeline(BasePipeline):
                     f"TaskPipeline: {issue_df.count()} issue rows for active resources after joining with issue type metadata"
                 )
                 logger.debug(
-                    f"TaskPipeline: {issue_df.filter((col('severity') == 'error') & (col('responsibility') == 'external')).count()} rows with severity=error and responsibility=external — these become issue tasks"
+                    f"TaskPipeline: {issue_df.filter(col('severity').isin('error', 'warning', 'notice')).count()} rows with severity in (error, warning, notice) — these become issue tasks"
                 )
+
             issue_tasks = transform_issues_to_tasks(issue_df)
 
         # -- Union and write --------------------------------------------------

--- a/src/jobs/transform/task_transformer.py
+++ b/src/jobs/transform/task_transformer.py
@@ -4,13 +4,16 @@ from datetime import date
 
 from pyspark.sql import DataFrame
 from pyspark.sql.functions import (
+    array_distinct,
     coalesce,
     col,
     concat_ws,
     count,
+    explode,
     first,
     lit,
     sha2,
+    split,
     struct,
     substring,
     to_json,
@@ -21,12 +24,14 @@ from jobs.utils.logger_config import get_logger
 logger = get_logger(__name__)
 
 
-# NOTE: This module mirrors the task transform logic in digital-land-python:
+# NOTE: This module mirrors some of the task transform logic in digital-land-python:
 # digital_land/pipeline/task.py (_transform_log_to_tasks, _transform_issues_to_tasks).
-# The two implementations use different frameworks (PySpark vs Polars) but must
-# produce identical output schemas and reference hashes for the same input data.
-# If you change filtering logic, grouping, details JSON structure, or the reference
-# hash inputs here, make the equivalent change there too (and vice versa).
+# transform_issues_to_tasks now intentionally diverges: it filters severity in
+# (error, warning, notice) with no responsibility filter, explodes ';'-separated
+# organisation values to one task row per organisation, and includes organisation
+# in the reference hash. digital-land-python's task.py still uses
+# severity=error/responsibility=external and a hash without organisation —
+# bring these back in sync if/when that implementation is updated to match.
 
 
 def transform_log_to_tasks(df: DataFrame, entry_date: str = None) -> DataFrame:
@@ -88,23 +93,28 @@ def transform_issues_to_tasks(df: DataFrame, entry_date: str = None) -> DataFram
     Transform an issue DataFrame into task rows.
 
     Expects df to already be filtered to active resources.
-    Filters to severity=error and responsibility=external, then groups
-    by dataset/resource/field/issue-type and counts rows.
     """
     entry_date = entry_date or str(date.today())
     logger.info("transform_issues_to_tasks: Starting")
 
-    df = df.filter((col("severity") == "error") & (col("responsibility") == "external"))
+    df = df.filter(col("severity").isin("error", "warning", "notice"))
 
     if df.rdd.isEmpty():
         logger.info("transform_issues_to_tasks: No matching issue rows found")
         return None
 
-    grouped = df.groupBy("dataset", "resource", "field", "issue_type").agg(
+    # array_distinct guards against an org appearing twice in the ';'-list,
+    # which would otherwise double-count this issue for that org.
+    df = df.withColumn(
+        "organisation", explode(array_distinct(split(col("organisation"), ";")))
+    )
+
+    grouped = df.groupBy(
+        "dataset", "resource", "field", "issue_type", "organisation"
+    ).agg(
         count("*").alias("count"),
         first("severity").alias("severity"),
         first("responsibility").alias("responsibility"),
-        first("organisation").alias("organisation"),
         first("endpoint").alias("endpoint"),
     )
 
@@ -140,6 +150,11 @@ def transform_issues_to_tasks(df: DataFrame, entry_date: str = None) -> DataFram
 
 
 def _add_reference(df: DataFrame) -> DataFrame:
+    """
+    Adds a `reference` column: a 16-char hex digest of dataset, organisation,
+    endpoint, resource, task_source and details. organisation is included so
+    that exploded per-organisation issue task rows.
+    """
     return df.withColumn(
         "reference",
         substring(
@@ -147,6 +162,7 @@ def _add_reference(df: DataFrame) -> DataFrame:
                 concat_ws(
                     "|",
                     coalesce(col("dataset"), lit("")),
+                    coalesce(col("organisation"), lit("")),
                     coalesce(col("endpoint"), lit("")),
                     coalesce(col("resource"), lit("")),
                     col("task_source"),

--- a/tests/integration/transform/test_task_transformer.py
+++ b/tests/integration/transform/test_task_transformer.py
@@ -297,7 +297,8 @@ ISSUE_COLUMNS = [
 
 class TestTransformIssuesToTasks:
 
-    def test_filters_out_warning_and_internal_rows(self, spark):
+    def test_includes_internal_responsibility_rows(self, spark):
+        """responsibility is no longer filtered — internal issues are now included."""
         df = _build_df(
             spark,
             [
@@ -316,7 +317,38 @@ class TestTransformIssuesToTasks:
                     "resource-aaa",
                     "name",
                     "missing-value",
-                    "warning",
+                    "notice",
+                    "internal",
+                    "organisation-x",
+                    "endpoint-aaa",
+                ),
+            ],
+            ISSUE_COLUMNS,
+        )
+        result = transform_issues_to_tasks(df)
+        assert result is not None
+        assert result.count() == 2
+
+    def test_excludes_info_severity_rows(self, spark):
+        df = _build_df(
+            spark,
+            [
+                (
+                    "dataset-a",
+                    "resource-aaa",
+                    "geometry",
+                    "invalid-geometry",
+                    "error",
+                    "external",
+                    "organisation-x",
+                    "endpoint-aaa",
+                ),
+                (
+                    "dataset-a",
+                    "resource-aaa",
+                    "name",
+                    "missing-value",
+                    "info",
                     "internal",
                     "organisation-x",
                     "endpoint-aaa",
@@ -337,7 +369,7 @@ class TestTransformIssuesToTasks:
                     "resource-aaa",
                     "name",
                     "missing-value",
-                    "warning",
+                    "info",
                     "internal",
                     "organisation-x",
                     "endpoint-aaa",
@@ -546,6 +578,111 @@ class TestTransformIssuesToTasks:
                     "organisation-x",
                     "endpoint-aaa",
                 ),
+            ],
+            ISSUE_COLUMNS,
+        )
+        result = transform_issues_to_tasks(df)
+        references = [row["reference"] for row in result.collect()]
+        assert len(references) == len(set(references))
+
+    def test_explodes_multi_org_into_one_task_per_organisation(self, spark):
+        df = _build_df(
+            spark,
+            [
+                (
+                    "dataset-a",
+                    "resource-aaa",
+                    "geometry",
+                    "invalid-geometry",
+                    "error",
+                    "external",
+                    "organisation-x;organisation-y",
+                    "endpoint-aaa",
+                )
+            ],
+            ISSUE_COLUMNS,
+        )
+        result = transform_issues_to_tasks(df)
+        rows = result.collect()
+        assert len(rows) == 2
+        assert {row["organisation"] for row in rows} == {
+            "organisation-x",
+            "organisation-y",
+        }
+
+    def test_duplicate_organisation_in_list_is_not_double_counted(self, spark):
+        df = _build_df(
+            spark,
+            [
+                (
+                    "dataset-a",
+                    "resource-aaa",
+                    "geometry",
+                    "invalid-geometry",
+                    "error",
+                    "external",
+                    "organisation-x;organisation-x",
+                    "endpoint-aaa",
+                )
+            ],
+            ISSUE_COLUMNS,
+        )
+        result = transform_issues_to_tasks(df)
+        rows = result.collect()
+        assert len(rows) == 1
+        assert json.loads(rows[0]["details"])["count"] == 1
+
+    def test_per_organisation_counts_after_explode(self, spark):
+        """An issue on a resource shared by two orgs, plus another issue on the
+        same resource/field affecting only one of them, should produce
+        per-organisation counts rather than one combined count."""
+        df = _build_df(
+            spark,
+            [
+                (
+                    "dataset-a",
+                    "resource-aaa",
+                    "geometry",
+                    "invalid-geometry",
+                    "error",
+                    "external",
+                    "organisation-x;organisation-y",
+                    "endpoint-aaa",
+                ),
+                (
+                    "dataset-a",
+                    "resource-aaa",
+                    "geometry",
+                    "invalid-geometry",
+                    "error",
+                    "external",
+                    "organisation-x",
+                    "endpoint-aaa",
+                ),
+            ],
+            ISSUE_COLUMNS,
+        )
+        result = transform_issues_to_tasks(df)
+        by_org = {row["organisation"]: row for row in result.collect()}
+        assert json.loads(by_org["organisation-x"]["details"])["count"] == 2
+        assert json.loads(by_org["organisation-y"]["details"])["count"] == 1
+
+    def test_exploded_org_rows_have_distinct_references(self, spark):
+        """organisation is part of the reference hash, so per-org rows from the
+        same source issue don't collide on the Postgres task_pkey."""
+        df = _build_df(
+            spark,
+            [
+                (
+                    "dataset-a",
+                    "resource-aaa",
+                    "geometry",
+                    "invalid-geometry",
+                    "error",
+                    "external",
+                    "organisation-x;organisation-y",
+                    "endpoint-aaa",
+                )
             ],
             ISSUE_COLUMNS,
         )


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This stops the pipeline filtering out issues where responsibility == "internal" it also expands the filtering to inlcude issues where severity is "warning" and "notice" as well as "error"

This adds an explode on organisation - so that we no longer have multiple organisations on the same task row e.g.  
 local-authority:ADU;local-authority:WOT but instead we will have two rows one for each ADU and WOT.


## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- [Ticket Link](https://github.com/digital-land/config/issues/2692)
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?
