### PR TITLE
fix: only pick latest active resource in tasks pipeline

### DIFF
--- a/src/jobs/pipeline.py
+++ b/src/jobs/pipeline.py
@@ -21,7 +21,7 @@ from functools import reduce
 import boto3
 from cloudpathlib import AnyPath, S3Path
 from pyspark.sql import SparkSession, Window
-from pyspark.sql.functions import col, explode, row_number, split
+from pyspark.sql.functions import col, explode, lit, row_number, split
 
 from jobs.config.metadata import load_metadata
 from jobs.read import read_old_resources
@@ -650,32 +650,36 @@ def _backfill_organisation_from_source(log_df, endpoint_organisation_df):
     return log_df.filter(col("organisation") != "").unionByName(resolved_df)
 
 
-def _select_active_resources(resource_df):
-    """
-    Return the active resources: one row per endpoint — the most recently started
-    resource with no end_date.
+def _active_resources_from_log(log_df, endpoint_attrs_df):
+    """The resource each endpoint is currently serving, derived from the log.
 
-    An endpoint should have exactly one active resource (its current content). Some
-    endpoints have several resources left without an end_date (a stale-un-end-dated
-    data bug); those old rows carry issues that would otherwise be regenerated as
-    phantom tasks pointing at superseded resources. Keeping only the latest per
-    endpoint guards against that.
+    dataset/organisation are attributed from source.csv (endpoint_attrs_df),
+    keyed on that endpoint, rather than from resource.csv's flattened sets.
     """
-    blank_end_date_df = resource_df.filter(
-        col("end_date").isNull() | (col("end_date") == "")
+    latest_per_endpoint = Window.partitionBy("endpoint").orderBy(
+        col("entry_date").desc(), col("resource").asc()
     )
-    latest_per_endpoint = Window.partitionBy("endpoints").orderBy(
-        col("start_date").desc_nulls_last(), col("resource").asc()
-    )
-    return (
-        blank_end_date_df.withColumn("_rank", row_number().over(latest_per_endpoint))
-        .filter(col("_rank") == 1)
-        .select(
-            "resource",
-            col("datasets").alias("dataset"),
-            col("organisations").alias("organisation"),
-            col("endpoints").alias("endpoint"),
+    current = (
+        log_df.filter(
+            (col("status") == "200")
+            & col("resource").isNotNull()
+            & (col("resource") != "")
         )
+        .withColumn("_rank", row_number().over(latest_per_endpoint))
+        .filter(col("_rank") == 1)
+        .select("endpoint", "resource")
+    )
+
+    if endpoint_attrs_df is not None:
+        current = current.join(endpoint_attrs_df, on="endpoint", how="left")
+    else:
+        current = current.withColumn("dataset", lit("")).withColumn(
+            "organisation", lit("")
+        )
+
+    return (
+        current.select("resource", "dataset", "organisation", "endpoint")
+        .fillna("", subset=["dataset", "organisation"])
         .distinct()
     )
 
@@ -695,11 +699,6 @@ class TaskPipeline(BasePipeline):
         base = AnyPath(self.config.collection_data_path)
 
         # -- Resolve file paths ---------------------------------------------------
-        resource_files = [
-            str(p) for p in base.glob("*-collection/collection/resource.csv")
-        ]
-        logger.info(f"TaskPipeline: Found {len(resource_files)} resource files")
-
         log_files = [str(p) for p in base.glob("*-collection/collection/log.csv")]
         logger.info(f"TaskPipeline: Found {len(log_files)} log files")
 
@@ -709,27 +708,21 @@ class TaskPipeline(BasePipeline):
         source_files = [str(p) for p in base.glob("*-collection/collection/source.csv")]
         logger.info(f"TaskPipeline: Found {len(source_files)} source files")
 
-        if not resource_files:
-            logger.warning("TaskPipeline: No resource files found — nothing to process")
-            return
-
-        # -- Active resources -------------------------------------------------
-        resource_df = spark.read.option("header", "true").csv(resource_files)
-        resource_df = normalise_column_names(resource_df)
-        active_df = _select_active_resources(resource_df)
-        active_df.cache()
-        logger.info("TaskPipeline: Active resources loaded (latest per endpoint)")
+        log_df = spark.read.option("header", "true").csv(log_files)
+        log_df = normalise_column_names(log_df)
 
         # -- Endpoint → dataset/organisation lookups (from source.csv) ----------
-        # Needed to fill in dataset for failed log entries where resource is blank.
-        # source.csv maps endpoint hash → pipelines (dataset name), with ';'
-        # separating multiple datasets when one endpoint serves more than one.
+        # source.csv maps endpoint hash → pipelines (dataset name) + organisation,
+        # with ';' separating multiple datasets when one endpoint serves several.
         if source_files:
             source_df = spark.read.option("header", "true").csv(source_files)
             source_df = normalise_column_names(source_df)
             active_source_df = source_df.filter(
                 col("end_date").isNull() | (col("end_date") == "")
             )
+
+            # Exploded (one row per endpoint+dataset) — backfills failed log
+            # entries, where a blank resource can't tell us the dataset.
             endpoint_dataset_df = active_source_df.select(
                 col("endpoint"),
                 explode(split(col("pipelines"), ";")).alias("dataset"),
@@ -739,32 +732,43 @@ class TaskPipeline(BasePipeline):
             endpoint_organisation_df = active_source_df.select(
                 "endpoint", "organisation"
             ).dropDuplicates(["endpoint"])
+
+            # One row per endpoint carrying its dataset(s) as the raw ';' string
+            # and organisation — attributes the active resource below. Kept as a
+            # single row per endpoint so the issue join stays one-to-one.
+            endpoint_attrs_df = active_source_df.select(
+                "endpoint",
+                col("pipelines").alias("dataset"),
+                "organisation",
+            ).dropDuplicates(["endpoint"])
         else:
             endpoint_dataset_df = None
             endpoint_organisation_df = None
+            endpoint_attrs_df = None
+
+        # -- Active resources (current resource per endpoint, from the log) ------
+        active_df = _active_resources_from_log(log_df, endpoint_attrs_df)
+        active_df.cache()
+        logger.info(
+            "TaskPipeline: Active resources loaded (current resource per endpoint from log)"
+        )
 
         # -- Log tasks --------------------------------------------------------
-        if not log_files:
-            logger.warning("TaskPipeline: No log files found — skipping log tasks")
-            log_tasks = None
-        else:
-            log_df = spark.read.option("header", "true").csv(log_files)
-            log_df = normalise_column_names(log_df)
-            log_df = log_df.join(
-                active_df.select("resource", "dataset", "organisation"),
-                on="resource",
-                how="left",
+        log_df = log_df.join(
+            active_df.select("resource", "dataset", "organisation"),
+            on="resource",
+            how="left",
+        )
+        log_df = log_df.fillna("", subset=["dataset", "organisation"])
+
+        if endpoint_dataset_df is not None:
+            log_df = _backfill_dataset_from_source(log_df, endpoint_dataset_df)
+        if endpoint_organisation_df is not None:
+            log_df = _backfill_organisation_from_source(
+                log_df, endpoint_organisation_df
             )
-            log_df = log_df.fillna("", subset=["dataset", "organisation"])
 
-            if endpoint_dataset_df is not None:
-                log_df = _backfill_dataset_from_source(log_df, endpoint_dataset_df)
-            if endpoint_organisation_df is not None:
-                log_df = _backfill_organisation_from_source(
-                    log_df, endpoint_organisation_df
-                )
-
-            log_tasks = transform_log_to_tasks(log_df)
+        log_tasks = transform_log_to_tasks(log_df)
 
         # -- Issue tasks ------------------------------------------------------
         if not issue_files:

--- a/src/jobs/pipeline.py
+++ b/src/jobs/pipeline.py
@@ -20,8 +20,8 @@ from functools import reduce
 
 import boto3
 from cloudpathlib import AnyPath, S3Path
-from pyspark.sql import SparkSession
-from pyspark.sql.functions import col, explode, split
+from pyspark.sql import SparkSession, Window
+from pyspark.sql.functions import col, explode, row_number, split
 
 from jobs.config.metadata import load_metadata
 from jobs.read import read_old_resources
@@ -650,6 +650,36 @@ def _backfill_organisation_from_source(log_df, endpoint_organisation_df):
     return log_df.filter(col("organisation") != "").unionByName(resolved_df)
 
 
+def _select_active_resources(resource_df):
+    """
+    Return the active resources: one row per endpoint — the most recently started
+    resource with no end_date.
+
+    An endpoint should have exactly one active resource (its current content). Some
+    endpoints have several resources left without an end_date (a stale-un-end-dated
+    data bug); those old rows carry issues that would otherwise be regenerated as
+    phantom tasks pointing at superseded resources. Keeping only the latest per
+    endpoint guards against that.
+    """
+    blank_end_date_df = resource_df.filter(
+        col("end_date").isNull() | (col("end_date") == "")
+    )
+    latest_per_endpoint = Window.partitionBy("endpoints").orderBy(
+        col("start_date").desc_nulls_last(), col("resource").asc()
+    )
+    return (
+        blank_end_date_df.withColumn("_rank", row_number().over(latest_per_endpoint))
+        .filter(col("_rank") == 1)
+        .select(
+            "resource",
+            col("datasets").alias("dataset"),
+            col("organisations").alias("organisation"),
+            col("endpoints").alias("endpoint"),
+        )
+        .distinct()
+    )
+
+
 class TaskPipeline(BasePipeline):
     """
     Cross-collection pipeline for generating task data from log and issue files.
@@ -686,18 +716,9 @@ class TaskPipeline(BasePipeline):
         # -- Active resources -------------------------------------------------
         resource_df = spark.read.option("header", "true").csv(resource_files)
         resource_df = normalise_column_names(resource_df)
-        active_df = (
-            resource_df.filter(col("end_date").isNull() | (col("end_date") == ""))
-            .select(
-                "resource",
-                col("datasets").alias("dataset"),
-                col("organisations").alias("organisation"),
-                col("endpoints").alias("endpoint"),
-            )
-            .distinct()
-        )
+        active_df = _select_active_resources(resource_df)
         active_df.cache()
-        logger.info("TaskPipeline: Active resources loaded")
+        logger.info("TaskPipeline: Active resources loaded (latest per endpoint)")
 
         # -- Endpoint → dataset/organisation lookups (from source.csv) ----------
         # Needed to fill in dataset for failed log entries where resource is blank.

--- a/tests/acceptance/test_run_tasks_acceptance.py
+++ b/tests/acceptance/test_run_tasks_acceptance.py
@@ -75,7 +75,14 @@ TREE_LOG_ROWS = [
     },
 ]
 
-RESOURCE_COLUMNS = ["resource", "datasets", "organisations", "endpoints", "end-date"]
+RESOURCE_COLUMNS = [
+    "resource",
+    "datasets",
+    "organisations",
+    "endpoints",
+    "start-date",
+    "end-date",
+]
 
 CA_RESOURCE_ROWS = [
     {
@@ -83,6 +90,7 @@ CA_RESOURCE_ROWS = [
         "datasets": "conservation-area",
         "organisations": "organisation:1",
         "endpoints": "endpoint-ca-aaa",
+        "start-date": "2026-07-01",
         "end-date": "",
     },
 ]

--- a/tests/integration/test_pipeline.py
+++ b/tests/integration/test_pipeline.py
@@ -18,6 +18,7 @@ from jobs.pipeline import (
     TaskPipeline,
     _backfill_dataset_from_source,
     _backfill_organisation_from_source,
+    _select_active_resources,
 )
 
 # -- Test data ----------------------------------------------------------------
@@ -501,13 +502,21 @@ class TestTaskPipeline:
 
         _write_csv(
             os.path.join(base, "test-collection", "collection", "resource.csv"),
-            ["resource", "datasets", "organisations", "endpoints", "end_date"],
+            [
+                "resource",
+                "datasets",
+                "organisations",
+                "endpoints",
+                "start_date",
+                "end_date",
+            ],
             [
                 {
                     "resource": "resource-aaa",
                     "datasets": "dataset-a",
                     "organisations": "organisation:1",
                     "endpoints": "http://endpoint-a",
+                    "start_date": "2026-01-01",
                     "end_date": "",
                 }
             ],
@@ -714,3 +723,32 @@ class TestBackfillOrganisationFromSource:
         rows = result.collect()
         assert len(rows) == 1
         assert rows[0]["organisation"] == ""
+
+
+def test_select_active_resources_keeps_latest_per_endpoint(spark):
+    """
+    An endpoint should have one active resource. Where several are left without an
+    end_date (the stale-un-end-dated bug), only the most recently started one is
+    kept — so old phantom resources don't generate tasks, while healthy single-active
+    endpoints and ended resources are handled correctly.
+    """
+    df = spark.createDataFrame(
+        [
+            ("res-current", "ds", "org", "ep-1", "2026-07-01", ""),  # current
+            ("res-phantom", "ds", "org", "ep-1", "2025-12-04", ""),  # stale, un-ended
+            ("res-other", "ds", "org", "ep-2", "2026-06-01", ""),  # single active
+            ("res-ended", "ds", "org", "ep-1", "2026-05-01", "2026-05-02"),  # ended
+        ],
+        [
+            "resource",
+            "datasets",
+            "organisations",
+            "endpoints",
+            "start_date",
+            "end_date",
+        ],
+    )
+
+    active = {row["resource"] for row in _select_active_resources(df).collect()}
+
+    assert active == {"res-current", "res-other"}

--- a/tests/integration/test_pipeline.py
+++ b/tests/integration/test_pipeline.py
@@ -16,9 +16,9 @@ from jobs.pipeline import (
     IssuePipeline,
     PipelineConfig,
     TaskPipeline,
+    _active_resources_from_log,
     _backfill_dataset_from_source,
     _backfill_organisation_from_source,
-    _select_active_resources,
 )
 
 # -- Test data ----------------------------------------------------------------
@@ -500,28 +500,6 @@ class TestTaskPipeline:
         base = str(tmp_path)
         parquet_base = os.path.join(base, "parquet-output/")
 
-        _write_csv(
-            os.path.join(base, "test-collection", "collection", "resource.csv"),
-            [
-                "resource",
-                "datasets",
-                "organisations",
-                "endpoints",
-                "start_date",
-                "end_date",
-            ],
-            [
-                {
-                    "resource": "resource-aaa",
-                    "datasets": "dataset-a",
-                    "organisations": "organisation:1",
-                    "endpoints": "http://endpoint-a",
-                    "start_date": "2026-01-01",
-                    "end_date": "",
-                }
-            ],
-        )
-
         # Same endpoint failing on two different dates — the key scenario.
         # entry-date and elapsed differ, which previously caused .distinct()
         # to keep both rows and produce duplicate reference hashes.
@@ -554,6 +532,15 @@ class TestTaskPipeline:
                     "entry-date": "2026-01-02",
                     "bytes": "200",
                     "elapsed": "1.1",
+                },
+                {
+                    "endpoint": "http://endpoint-a",
+                    "resource": "resource-aaa",
+                    "status": "200",
+                    "exception": "",
+                    "entry-date": "2026-01-03",
+                    "bytes": "200",
+                    "elapsed": "1.0",
                 },
             ],
         )
@@ -725,30 +712,31 @@ class TestBackfillOrganisationFromSource:
         assert rows[0]["organisation"] == ""
 
 
-def test_select_active_resources_keeps_latest_per_endpoint(spark):
-    """
-    An endpoint should have one active resource. Where several are left without an
-    end_date (the stale-un-end-dated bug), only the most recently started one is
-    kept — so old phantom resources don't generate tasks, while healthy single-active
-    endpoints and ended resources are handled correctly.
-    """
-    df = spark.createDataFrame(
+def test_active_resources_from_log_uses_latest_successful_per_endpoint(spark):
+    log_df = spark.createDataFrame(
         [
-            ("res-current", "ds", "org", "ep-1", "2026-07-01", ""),  # current
-            ("res-phantom", "ds", "org", "ep-1", "2025-12-04", ""),  # stale, un-ended
-            ("res-other", "ds", "org", "ep-2", "2026-06-01", ""),  # single active
-            ("res-ended", "ds", "org", "ep-1", "2026-05-01", "2026-05-02"),  # ended
+            # endpoint-a: an older (now superseded) resource + the current one
+            ("endpoint-a", "resource-old", "200", "2026-01-01"),
+            ("endpoint-a", "resource-current", "200", "2026-02-01"),
+            # a resource that only ever failed here → must not be active
+            ("endpoint-b", "resource-fail", "404", "2026-02-01"),
         ],
+        ["endpoint", "resource", "status", "entry_date"],
+    )
+    endpoint_attrs_df = spark.createDataFrame(
         [
-            "resource",
-            "datasets",
-            "organisations",
-            "endpoints",
-            "start_date",
-            "end_date",
+            ("endpoint-a", "dataset-a", "org:1"),
+            ("endpoint-b", "dataset-b", "org:2"),
         ],
+        ["endpoint", "dataset", "organisation"],
     )
 
-    active = {row["resource"] for row in _select_active_resources(df).collect()}
+    active = _active_resources_from_log(log_df, endpoint_attrs_df)
+    rows = {
+        (r["endpoint"], r["resource"], r["dataset"], r["organisation"])
+        for r in active.collect()
+    }
 
-    assert active == {"res-current", "res-other"}
+    # Only endpoint-a's latest 200 survives; the superseded resource and the
+    # never-successful endpoint-b are both excluded.
+    assert rows == {("endpoint-a", "resource-current", "dataset-a", "org:1")}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Change the Task Generation Pipeline so that we figure out which issue is produced by which endpoint (and therefore which organisation and dataset) using the logs rather than resource.csv

## How we pick the right log for a given issue

For each collection the pipeline reads the collection `log`, the `issue` files, and `source.csv`, then determines the **current resource for every endpoint as the latest successful (`200`) fetch in the log** — the log being the authoritative record of what resource each endpoint actually served. 

## Why

The log.csv contains an exact map of which `endpoint` generates which `resource` unlike resource.csv (see section below) this change should enable all issue tasks to be correctly allocated to the right dataset for the right LPA dashboard, and avoid the phantom tasks described in the attached ticket.

## Background of Task Pipeline, to explain why resource.csv cannot give us the fidelity we need. (More just Tom thinking out loud than anything)

One of the big challenges of the task pipelines to match up "error in an issue or log file" with "organisation + dataset" so that the error can be displayed as a task in the right section (dataset) of the right LPA dashboard (organisation). 

Doing this for Logs is relatively easy. Every log as an endpoint field which contains a value and the source.csv contains rows each with an endpoint, an organisation and a dataset, so we just join these together on endpoint and hey presto we have the dataset we need. 

Matching this up for issues is more difficult. We have issues and resources but they don't map neatly onto endpoints: 

                               issue → resource → ??? → endpoint → organisation → dashboard   

The above ticket is all about coming up with a better solution to this mapping problem.

resource.csv is created to try and bridge this gap but it only works reliably one direction. 

The resource.csv is a summary of all the logs, all the logs get grouped together by resource and if they came from multiple endpoints then those endpoints get listed together in one field separated by `;`s.

so for example 4 logs: 

| endpoint | resource   | status | entry-date |
|----------|------------|--------|------------|
| URL-A    | resource-1 | 200    | 2026-01-01 |
| URL-A    | resource-1 | 200    | 2026-01-02 |
| URL-B    | resource-1 | 200    | 2026-01-01 |
| URL-B    | resource-1 | 200    | 2026-01-02 |

can become 1 row in the resource.csv

| resource   | endpoints   | organisations       | datasets          | start-date | end-date  |
|------------|-------------|---------------------|-------------------|------------|-----------|
| resource-1 | URL-A;URL-B | council-X;council-Y | conservation-area | 2026-01-01 | *(blank)* |

But this only works in one direction. Its fine if you want to go from many-to-one but is a problem when you go from one-to-many.

The resource end-date is calculated by just looking to see if this resource is the most recently produced by **any** of the endpoints that produce it. 

So in the example above if URL-A stops producing resource-1 and moves on to resource-2, but URL-B merrily carryies on producing resource-1 then the row in our resource.csv will stay as it is with URL-A listed in the endpoints implying that URL-A is producing resource-1 which actually it isn't any more. If this resource contains a Task this produces the Phantom task this ticket is trying to prevent.

So we cannot use resource.csv to figure out how to connect an issue to an endpoint which in turn connects it to an organisation and dataset. Instead we must use the logs.


## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- [Ticket Link](https://github.com/digital-land/config/issues/2758)
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

## Test in Staging
There are only 3 examples endpoints with multiple active resources and none of them produce tasks so I can't check this solves the problem in staging. 

However I have run the this version of the pipeline in staging and it now produces 3220 tasks up 722 from the 2498 it was producing before the change.

This change breaks down into:   **843 tasks added, 121 removed**.

## The 843 added tasks

These are all *issue* tasks (no log/failure tasks changed).

- **474** — on **226 endpoints that previously produced no tasks at all**.
  `resource.csv` wasn't giving us a usable "current resource" for these endpoints,
  so their real issues never surfaced. The log now identifies the correct current
  resource, so the issues attached to it correctly appear.
- **360** — on endpoints that already had tasks, where the **active resource
  changed**: `resource.csv` had the endpoint pointing at an older resource, and the
  log points at the current one, so the current resource's issues appear.
- **9** — same resource as before, but the **organisation was re-attributed**. We
  now source `organisation` from `source.csv` (the authoritative endpoint→org
  mapping) rather than resource.csv's flattened set.

Every added task maps to a genuine dataset (mostly `brownfield-land` and
`conservation-area`), so these are real, previously-missing issues rather than noise.

## The 121 removed tasks

These were being generated against a resource that `resource.csv` treated as
"current" but which the log shows is actually **superseded** — the endpoint has
since served a newer resource. Because they point at data the platform no longer
serves, they were stale/misleading and are correctly dropped. They're concentrated
in `brownfield-land` (88), the same high-churn collection where the added tasks
cluster, consistent with `resource.csv` being unreliable there.

## Owens question

Owen asked me to check that now a pipeline comes from source.csv where pipelines [can be comma separated](https://github.com/digital-land/config/blob/c390b0c60beac5747c5c3ff83224c507a7462730/collection/tree-preservation-order/source.csv#L14). Will this new code correctly separate them out.

For issue tasks (the bulk), the dataset comes from the issue file itself — a resource served by a tree-preservation-order;tree endpoint gets processed by both the pipelines during collection, which write separate issue files under issue/tree-preservation-order/ and issue/tree/, each already tagged with its single dataset, so they become correctly-split tasks. For failed-log tasks, the dataset comes from endpoint_dataset_df, which is built with explode(split(col("pipelines"), ";")) — i.e. it splits the semicolon list into one row per dataset. So both task types split multi-pipeline endpoints correctly, just via different mechanisms.


## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?
