### PR TITLE
feat: filter active datasets for provision-quality job

### DIFF
--- a/src/jobs/pipeline.py
+++ b/src/jobs/pipeline.py
@@ -863,9 +863,9 @@ def _owner_side(eq):
 
 
 def _seeder_alt_sources(eq, lookup_df, entity_org_df, active_orgs):
-    """Seeder (alt-source) detection, per Sian's step 5. An active org that seeded
-    'some'-quality entities it does NOT own and is NOT designated for counts as a
-    'some' contributor. LA-type orgs must have seeded for >1 distinct owner to
+    """Seeder (alt-source) detection. An active org that seeded 'some'-quality
+    entities it does NOT own and is NOT designated for counts as a 'some'
+    contributor. LA-type orgs must have seeded for >1 distinct owner to
     count (stale-lookup guard); other org types need >=1."""
     some_ent = eq.filter(col("quality") == "some").select(
         "dataset", "entity", col("organisation").alias("owner_org")
@@ -916,12 +916,36 @@ def _seeder_alt_sources(eq, lookup_df, entity_org_df, active_orgs):
     )
 
 
+def _live_datasets(dataset_df, env):
+    """The datasets the platform builds in `env` and has not retired.
+
+    Mirrors is_dataset_available in airflow-dags (dags/utils.py): a
+    `production` dataset is built in every environment, `staging` only in
+    staging and development, `development` only in development, and a blank
+    environment is not built anywhere. An end-dated dataset is retired
+    whatever its environment (e.g. development-plan-document, which is
+    production but was end-dated in February).
+    """
+    available = col("environment") == "production"
+    if env in ("staging", "development"):
+        available = available | (col("environment") == "staging")
+    if env == "development":
+        available = available | (col("environment") == "development")
+
+    return (
+        dataset_df.filter(available)
+        .filter(col("end_date").isNull() | (col("end_date") == ""))
+        .select("dataset")
+        .distinct()
+    )
+
+
 def _build_provision_quality(
     providers_df, org_df, entity_org_df, lookup_df, entity_quality_df
 ):
     """Base table: one row per (dataset, organisation) that has an active endpoint
     OR owns entities OR is a detected seeder. Nothing dropped; flags distinguish
-    the cases. Ports Sian's owner/provider classification + seeder detection."""
+    the cases. Owner/provider classification + seeder detection."""
     # map each owned entity to its owner organisation reference
     eq = entity_quality_df.join(
         org_df.select("organisation", "organisation_entity"),
@@ -1028,8 +1052,8 @@ class ProvisionQualityPipeline(BasePipeline):
     Cross-collection pipeline computing provider/organisation quality per
     (dataset, organisation). Reads across all collections at once (wildcard S3
     paths) like TaskPipeline. Phase 1 writes three CSVs; phase 2 will add Delta
-    + Postgres. Classification is ported from the Data Design analysis
-    (jupyter-analysis: count_organisations_providers_platform).
+    + Postgres. Classification follows the agreed provider/organisation
+    quality definitions (see the Provision Quality technical documentation).
     """
 
     def execute(self, entity_data_path, output_path):
@@ -1083,15 +1107,41 @@ class ProvisionQualityPipeline(BasePipeline):
             spark, lookup_files, ["entity", "organisation"]
         )  # who seeded each entity
 
+        # -- Live datasets (specification/dataset.csv) --------------------------
+        # Restrict to datasets the platform still builds in this environment;
+        # retired ones linger in the CSVs (e.g. local-plan-timetable) in s3.
+        dataset_path = str(base / "specification" / "dataset.csv")
+        dataset_df = normalise_column_names(
+            spark.read.option("header", "true").csv(dataset_path)
+        )
+        live_datasets_df = _live_datasets(dataset_df, self.config.env)
+
         # -- Entity + quality (SWAPPABLE SEAM) ----------------------------------
         entity_quality_df = self.load_entity_quality(spark, entity_data_path)
 
-        # -- Classification + rollups (todo 3/4 — port of Sian's logic) ---------
+        # -- Classification + rollups ------------------------------------------
         provision_quality = _build_provision_quality(
             providers_df, org_df, entity_org_df, lookup_df, entity_quality_df
         ).localCheckpoint(
             eager=True
         )  # materialise once AND truncate the huge plan
+
+        # Log what the specification filter removes before applying it, so a
+        # dataset disappearing from the output is never silent.
+        dropped = (
+            provision_quality.select("dataset")
+            .distinct()
+            .join(live_datasets_df, on="dataset", how="left_anti")
+        )
+        dropped_names = sorted(row["dataset"] for row in dropped.collect())
+        if dropped_names:
+            logger.info(
+                f"ProvisionQuality: excluding {len(dropped_names)} dataset(s) not live "
+                f"in {self.config.env}: {', '.join(dropped_names)}"
+            )
+        provision_quality = provision_quality.join(
+            live_datasets_df, on="dataset", how="left_semi"
+        )
 
         dataset_quality = _build_dataset_quality(provision_quality)
         organisation_quality = _build_organisation_quality(provision_quality)

--- a/src/jobs/pipeline.py
+++ b/src/jobs/pipeline.py
@@ -968,7 +968,7 @@ def _build_provision_quality(
 
     pq = (
         keys.join(
-            providers.withColumn("has_active_endpoint", lit(True)),
+            providers_df.withColumn("has_active_endpoint", lit(True)),
             on=["dataset", "organisation"],
             how="left",
         )
@@ -991,6 +991,7 @@ def _build_provision_quality(
         "organisation",
         "organisation_name",
         coalesce(col("has_active_endpoint"), lit(False)).alias("has_active_endpoint"),
+        coalesce(col("has_active_resource"), lit(False)).alias("has_active_resource"),
         coalesce(col("owns_entities"), lit(False)).alias("owns_entities"),
         coalesce(col("is_designated_provider"), lit(False)).alias(
             "is_designated_provider"
@@ -1067,7 +1068,7 @@ class ProvisionQualityPipeline(BasePipeline):
         source_df = self._read_csvs_by_name(
             spark, source_files, ["endpoint", "end_date", "organisation", "pipelines"]
         )
-        providers_df = (
+        active_sources = (
             source_df.filter(
                 (col("endpoint").isNotNull() & (col("endpoint") != ""))
                 & (col("end_date").isNull() | (col("end_date") == ""))
@@ -1075,8 +1076,44 @@ class ProvisionQualityPipeline(BasePipeline):
             .select(
                 explode(split(col("pipelines"), ";")).alias("dataset"),
                 col("organisation"),
+                col("endpoint"),
             )
             .distinct()
+        )
+
+        # -- Active resources (resource.csv → is data still arriving) -----------
+        # A resource's end-date is the last date the collector saw it, so blank
+        # means it was fetched today. An endpoint can be configured and active
+        # while nothing actually arrives. `endpoints` is ';'-joined where
+        # several endpoints produced identical content.
+        resource_files = [
+            str(p) for p in base.glob("*-collection/collection/resource.csv")
+        ]
+        logger.info(f"ProvisionQuality: Found {len(resource_files)} resource files")
+        resource_df = self._read_csvs_by_name(
+            spark, resource_files, ["endpoints", "end_date"]
+        )
+        delivering_endpoints = (
+            resource_df.filter(col("end_date").isNull() | (col("end_date") == ""))
+            .select(explode(split(col("endpoints"), ";")).alias("endpoint"))
+            .distinct()
+        )
+
+        # an organisation is still delivering a dataset if ANY of its active
+        # endpoints for it still has a resource arriving
+        delivering = (
+            active_sources.join(delivering_endpoints, on="endpoint", how="left_semi")
+            .select("dataset", "organisation")
+            .distinct()
+        )
+        providers_df = (
+            active_sources.select("dataset", "organisation")
+            .distinct()
+            .join(
+                delivering.withColumn("has_active_resource", lit(True)),
+                on=["dataset", "organisation"],
+                how="left",
+            )
         )
 
         # -- Organisation reference (organisation.csv) --------------------------

--- a/tests/integration/test_pipeline.py
+++ b/tests/integration/test_pipeline.py
@@ -760,11 +760,15 @@ def _provision_quality_inputs(spark):
     - Adur  : active endpoint + owns authoritative entities            -> authoritative
     - Lewes : no endpoint, owns entities seeded on its behalf ('some') -> some
     - MHCLG : national seeder, has endpoint, owns nothing, seeded Lewes -> some
-    - New LA: active endpoint, owns nothing, seeds nothing (kept + flagged, null)
+    - New LA: active endpoint but nothing arriving (kept + flagged, null)
     """
     providers_df = spark.createDataFrame(
-        [(PQ_DATASET, PQ_ADU), (PQ_DATASET, PQ_MHCLG), (PQ_DATASET, PQ_NEW)],
-        ["dataset", "organisation"],
+        [
+            (PQ_DATASET, PQ_ADU, True),
+            (PQ_DATASET, PQ_MHCLG, True),
+            (PQ_DATASET, PQ_NEW, None),  # endpoint configured, no resource arriving
+        ],
+        ["dataset", "organisation", "has_active_resource"],
     )
     org_df = spark.createDataFrame(
         [
@@ -805,6 +809,7 @@ class TestProvisionQuality:
 
         adu = rows[PQ_ADU]
         assert adu["has_active_endpoint"] is True
+        assert adu["has_active_resource"] is True
         assert adu["owns_entities"] is True
         assert adu["is_designated_provider"] is True
         assert adu["quality"] == "authoritative"
@@ -812,6 +817,7 @@ class TestProvisionQuality:
 
         lew = rows[PQ_LEW]
         assert lew["has_active_endpoint"] is False  # owns but never submitted
+        assert lew["has_active_resource"] is False  # no endpoint, so nothing arriving
         assert lew["owns_entities"] is True
         assert lew["is_designated_provider"] is True
         assert lew["quality"] == "some"
@@ -819,6 +825,7 @@ class TestProvisionQuality:
 
         mhclg = rows[PQ_MHCLG]
         assert mhclg["has_active_endpoint"] is True
+        assert mhclg["has_active_resource"] is True
         assert mhclg["owns_entities"] is False  # provider that owns nothing
         assert mhclg["is_designated_provider"] is False
         assert mhclg["quality"] == "some"  # via seeder detection
@@ -826,6 +833,8 @@ class TestProvisionQuality:
 
         new = rows[PQ_NEW]
         assert new["has_active_endpoint"] is True
+        # endpoint is configured but its resource has stopped arriving
+        assert new["has_active_resource"] is False
         assert new["owns_entities"] is False
         assert new["quality"] is None  # endpoint but no data — kept + flagged
         assert new["entity_count"] == 0


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update



## Change 1  -  Only report on datasets the platform actually has

### Description

Filter against which datasets to collect ownership data on using `specification/dataset.csv`. A dataset is included if it's live in the environment we're running in (the same rule the DAGs use to decide what to build) and hasn't been end-dated. Applied once to the base table, so both rollups inherit it. Excluded datasets are logged rather than silently dropped.

Takes PROD from ~126 datasets to 111.

### Why
The job had no master list of datasets for ownership the pipeline discovered datasets by reading the **filenames** of the entity CSVs in S3. That folder accumulates: each collection syncs its own files into it, so it contains old, no longer used datasets which we should not be collecting provision quality for.


## Change 2 -  New `has_active_resource` column

### Description
Add a new column to show 'has_active_resource column to provision-quality.csv

### Why
`has_active_endpoint` tells you an endpoint is configured. It doesn't tell you anything is still arriving through it — an endpoint can be active while its resource stopped coming in months ago. The two look identical in the current output.

`has_active_resource` fills that gap, derived from each collection's `resource.csv`: a resource's `end-date` is the last date the collector saw it, so a blank end-date means it was fetched today. True if any of the organisation's active endpoints is still delivering — same grain as `has_active_endpoint`.


## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- [Ticket Link](https://github.com/digital-land/config/issues/2771)
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

Have tested in staging, task ran without errors, the data output looks good. Ready for PROD.

### One thing to note
This will make the pipeline take an extra 45 mins to run.... which is not necessarily a problem but does mean that we should bump up the priority list the work on speeding up the Glob code that finds each csv.

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?
