### PR TITLE
feat: make delta table and pg table for provision_quality

### DIFF
--- a/entry_points/run_provision_quality.py
+++ b/entry_points/run_provision_quality.py
@@ -3,10 +3,11 @@ run_provision_quality.py
 
 Entry point for the provision-quality job on Amazon EMR Serverless.
 
-Computes provider/organisation quality per dataset across all collections and
-writes three CSVs (provision-quality, dataset-quality, organisation-quality) to
-the collection-data bucket. Phase 1: CSV only (for review). Phase 2 will add
-Delta + serving Postgres writes.
+Computes provider/organisation quality per (dataset, organisation) across all
+collections and writes each of the three tables (provision-quality,
+dataset-quality, organisation-quality) three ways: CSV to the collection-data
+bucket (public download), Delta to the parquet-datasets bucket, and serving
+Postgres.
 
 Usage:
 1. Package code into a .whl using setup.py.
@@ -24,6 +25,7 @@ import click
 from jobs import job
 
 logger = logging.getLogger(__name__)
+
 
 @click.command()
 @click.option(
@@ -50,9 +52,27 @@ logger = logging.getLogger(__name__)
     default=None,
     help="Where the CSVs are written (default: s3://{env}-collection-data/dataset/)",
 )
+@click.option(
+    "--parquet-datasets-path",
+    default=None,
+    help="Output path for the Delta tables (default: s3://{env}-parquet-datasets/)",
+)
+@click.option(
+    "--database-url",
+    default=None,
+    help="PostgreSQL connection URL (default: resolved from AWS Secrets Manager)",
+)
 @click.option("--debug", is_flag=True, default=False, help="Enable DEBUG logging")
-def run(env, collection_data_path, entity_data_path, output_path, debug):
-    """Generate provision-quality CSVs across all collections."""
+def run(
+    env,
+    collection_data_path,
+    entity_data_path,
+    output_path,
+    parquet_datasets_path,
+    database_url,
+    debug,
+):
+    """Generate provision-quality outputs (CSV + Delta + Postgres)."""
     logging.basicConfig(
         level=logging.DEBUG if debug else logging.INFO,
         format="[%(asctime)s] %(levelname)s - %(name)s:%(lineno)d - %(message)s",
@@ -65,8 +85,11 @@ def run(env, collection_data_path, entity_data_path, output_path, debug):
         entity_data_path=entity_data_path
         or f"s3://digital-land-{env}-collection-dataset-hoisted/data/",
         output_path=output_path or f"s3://{env}-collection-data/dataset/",
+        parquet_datasets_path=parquet_datasets_path or f"s3://{env}-parquet-datasets/",
         env=env,
+        database_url=database_url,
     )
+
 
 if __name__ == "__main__":
     try:

--- a/src/jobs/job.py
+++ b/src/jobs/job.py
@@ -420,15 +420,19 @@ def generate_provision_quality(
     collection_data_path: str,
     entity_data_path: str,
     output_path: str,
+    parquet_datasets_path: str,
     env: str,
+    database_url: str = None,
 ):
     """
-    Generate provision-quality data across all collections (phase 1: CSV only).
+    Generate provision-quality data across all collections.
 
     Reads source.csv, organisation.csv, config (entity-organisation.csv / lookup.csv)
     and the flattened per-dataset entity CSVs, classifies provider/organisation
-    quality per (dataset, organisation), and writes three CSVs to output_path:
-    provision-quality.csv, dataset-quality.csv, organisation-quality.csv.
+    quality per (dataset, organisation), and writes each of the three tables three
+    ways: CSVs to output_path (public download), Delta to parquet_datasets_path,
+    and serving Postgres. database_url resolves from AWS Secrets Manager if not
+    passed.
     """
     allowed_envs = ["development", "staging", "production", "local"]
     if env not in allowed_envs:
@@ -440,6 +444,15 @@ def generate_provision_quality(
         logger.info(
             f"generate_provision_quality: Local collection_data_path: {collection_data_path}"
         )
+
+    if database_url is None:
+        logger.info(
+            "generate_provision_quality: No database_url provided, resolving from AWS Secrets Manager"
+        )
+        conn_params = get_aws_secret(env)
+        database_url = build_database_url(conn_params)
+    else:
+        logger.info("generate_provision_quality: Using provided database_url")
 
     logger.info(
         "generate_provision_quality: Starting cross-collection provision quality"
@@ -456,8 +469,8 @@ def generate_provision_quality(
             dataset="",
             env=env,
             collection_data_path=collection_data_path,
-            parquet_datasets_path="",  # unused in phase 1 (no Delta yet)
-            database_url="",  # unused in phase 1 (no Postgres yet)
+            parquet_datasets_path=parquet_datasets_path,
+            database_url=database_url,
         )
 
         pipeline = ProvisionQualityPipeline(config)

--- a/src/jobs/pipeline.py
+++ b/src/jobs/pipeline.py
@@ -56,6 +56,7 @@ from jobs.utils.postgres_writer_utils import (
     SUBDIVIDED_DATASETS,
     write_dataframe_to_postgres_jdbc,
     write_entity_subdivided_to_postgres,
+    write_table_to_postgres,
     write_task_to_postgres,
 )
 from jobs.utils.s3_writer_utils import (
@@ -1048,6 +1049,45 @@ def _build_organisation_quality(provision_quality):
     )
 
 
+def _drop_blank_organisations(df):
+    """Drop rows with no organisation — a blank org can't key a table
+    (organisation is a NOT NULL primary key). Rollups already exclude them."""
+    return df.filter(col("organisation").isNotNull() & (col("organisation") != ""))
+
+
+PROVISION_QUALITY_PG_TYPES = [
+    ("dataset", "TEXT"),
+    ("organisation", "TEXT"),
+    ("organisation_name", "TEXT"),
+    ("has_active_endpoint", "BOOLEAN"),
+    ("has_active_resource", "BOOLEAN"),
+    ("owns_entities", "BOOLEAN"),
+    ("is_designated_provider", "BOOLEAN"),
+    ("quality", "TEXT"),
+    ("entity_count", "BIGINT"),
+    ("quality_score", "DOUBLE PRECISION"),
+]
+
+DATASET_QUALITY_PG_TYPES = [
+    ("dataset", "TEXT"),
+    ("authoritative_organisations", "INTEGER"),
+    ("some_organisations", "INTEGER"),
+    ("total_organisations", "INTEGER"),
+    ("total_entities", "BIGINT"),
+    ("quality_score", "DOUBLE PRECISION"),
+]
+
+ORGANISATION_QUALITY_PG_TYPES = [
+    ("organisation", "TEXT"),
+    ("organisation_name", "TEXT"),
+    ("authoritative_datasets", "INTEGER"),
+    ("some_datasets", "INTEGER"),
+    ("total_datasets", "INTEGER"),
+    ("total_entities_owned", "BIGINT"),
+    ("quality_score", "DOUBLE PRECISION"),
+]
+
+
 class ProvisionQualityPipeline(BasePipeline):
     """
     Cross-collection pipeline computing provider/organisation quality per
@@ -1178,6 +1218,8 @@ class ProvisionQualityPipeline(BasePipeline):
             live_datasets_df, on="dataset", how="left_semi"
         )
 
+        provision_quality = _drop_blank_organisations(provision_quality)
+
         dataset_quality = _build_dataset_quality(provision_quality)
         organisation_quality = _build_organisation_quality(provision_quality)
 
@@ -1198,6 +1240,32 @@ class ProvisionQualityPipeline(BasePipeline):
             output_path,
             "organisation-quality",
         )
+
+        # -- Write Delta (canonical) + Postgres (serving) ----------------------
+        outputs = [
+            ("provision_quality", provision_quality, PROVISION_QUALITY_PG_TYPES),
+            ("dataset_quality", dataset_quality, DATASET_QUALITY_PG_TYPES),
+            (
+                "organisation_quality",
+                organisation_quality,
+                ORGANISATION_QUALITY_PG_TYPES,
+            ),
+        ]
+        for name, frame, _ in outputs:
+            delta_path = str(AnyPath(self.config.parquet_datasets_path) / name)
+            logger.info(f"ProvisionQuality: Writing Delta table to {delta_path}")
+            frame.write.format("delta").mode("overwrite").option(
+                "overwriteSchema", "true"
+            ).save(delta_path)
+
+        if self.config.database_url:
+            for name, frame, pg_types in outputs:
+                logger.info(f"ProvisionQuality: Writing {name} to Postgres")
+                write_table_to_postgres(frame, name, pg_types, self.config.database_url)
+        else:
+            logger.info(
+                "ProvisionQuality: No database_url provided — skipping Postgres writes"
+            )
 
     def _read_csvs_by_name(self, spark, files, columns):
         """Read many CSVs per-file and unionByName on the named columns.

--- a/src/jobs/utils/postgres_writer_utils.py
+++ b/src/jobs/utils/postgres_writer_utils.py
@@ -820,3 +820,134 @@ def write_task_to_postgres(df, database_url):
         conn.close()
     except Exception as e:
         logger.warning(f"write_task_to_postgres: Cleanup failed: {e}")
+
+
+def write_table_to_postgres(df, table_name, column_types, database_url):
+    """Write a DataFrame to a Postgres table via a staging table + atomic swap.
+
+    Generic form of write_task_to_postgres: the whole table is replaced
+    atomically (TRUNCATE + INSERT from staging), so there is never a partial
+    state. The staging DDL and the INSERT column list are built from
+    column_types, so one function serves several tables. The target table must
+    already exist (created by an Alembic migration); this only fills it.
+
+    Args:
+        df: Spark DataFrame whose columns cover every name in column_types.
+        table_name: Target table to replace.
+        column_types: ordered list of (column_name, postgres_type) tuples,
+            matching the target table's columns.
+        database_url: postgresql://user:pass@host:port/dbname
+    """
+    conn_params = parse_database_url(database_url)
+    columns = [name for name, _ in column_types]
+
+    # JDBC append is positional, so align the DataFrame to the staging DDL order
+    df = df.select(*columns)
+    row_count = df.count()
+    logger.info(f"write_table_to_postgres: Writing {row_count:,} rows to {table_name}")
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    hash_suffix = hashlib.md5(f"{table_name}_{timestamp}".encode()).hexdigest()[:8]
+    staging_table = f"{table_name}_staging_{hash_suffix}_{timestamp}"
+
+    # Step 1: create staging table with the same columns/types as the target
+    ddl_cols = ", ".join(f"{name} {sql_type}" for name, sql_type in column_types)
+    try:
+        conn_params["timeout"] = 1800
+        conn = pg8000.connect(**conn_params)
+        cur = conn.cursor()
+        cur.execute(f"CREATE TABLE {staging_table} ({ddl_cols});")
+        conn.commit()
+        cur.close()
+        conn.close()
+        logger.info(f"write_table_to_postgres: Created staging table {staging_table}")
+    except Exception as e:
+        logger.error(f"write_table_to_postgres: Failed to create staging table: {e}")
+        raise
+
+    # Step 2: JDBC write to staging, with retry
+    url = f"jdbc:postgresql://{conn_params['host']}:{conn_params['port']}/{conn_params['database']}"
+    num_partitions = max(1, min(10, row_count // 50000))
+    max_attempts = 3
+    attempt = 0
+    while attempt < max_attempts:
+        try:
+            df.repartition(num_partitions).write.jdbc(
+                url=url,
+                table=staging_table,
+                mode="append",
+                properties={
+                    "user": conn_params["user"],
+                    "password": conn_params["password"],
+                    "driver": "org.postgresql.Driver",
+                    "stringtype": "unspecified",
+                    "batchsize": "5000",
+                    "reWriteBatchedInserts": "true",
+                },
+            )
+            logger.info(
+                f"write_table_to_postgres: JDBC write successful on attempt {attempt + 1}"
+            )
+            break
+        except Exception as e:
+            attempt += 1
+            logger.warning(
+                f"write_table_to_postgres: JDBC write failed (attempt {attempt}): {e}"
+            )
+            if attempt < max_attempts:
+                time.sleep(5 * attempt)
+            else:
+                raise
+
+    # Step 3: atomic swap — TRUNCATE target, INSERT from staging
+    col_list = ", ".join(columns)
+    attempt = 0
+    while attempt < max_attempts:
+        try:
+            conn_params["timeout"] = 1800
+            conn = pg8000.connect(**conn_params)
+            cur = conn.cursor()
+            cur.execute("SET statement_timeout = '1800000';")
+            cur.execute("BEGIN;")
+            cur.execute(f"TRUNCATE TABLE {table_name};")
+            cur.execute(
+                f"INSERT INTO {table_name} ({col_list}) "
+                f"SELECT {col_list} FROM {staging_table};"
+            )
+            inserted = cur.rowcount
+            cur.execute(f"DROP TABLE {staging_table};")
+            cur.execute("COMMIT;")
+            logger.info(
+                f"write_table_to_postgres: Inserted {inserted:,} rows into {table_name}"
+            )
+            break
+        except Exception as e:
+            try:
+                cur.execute("ROLLBACK;")
+            except Exception:
+                pass
+            attempt += 1
+            logger.warning(
+                f"write_table_to_postgres: Atomic commit failed (attempt {attempt}): {e}"
+            )
+            if attempt < max_attempts:
+                time.sleep(5 * attempt)
+            else:
+                raise
+        finally:
+            try:
+                cur.close()
+                conn.close()
+            except Exception:
+                pass
+
+    # Step 4: safety cleanup
+    try:
+        conn = pg8000.connect(**conn_params)
+        cur = conn.cursor()
+        cur.execute(f"DROP TABLE IF EXISTS {staging_table};")
+        conn.commit()
+        cur.close()
+        conn.close()
+    except Exception as e:
+        logger.warning(f"write_table_to_postgres: Cleanup failed: {e}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -197,3 +197,91 @@ def clean_entity_subdivided_table(db_conn):
     )
     db_conn.commit()
     cur.close()
+
+
+@pytest.fixture()
+def clean_provision_quality_table(db_conn):
+    """Create the provision_quality table before each test, truncate after."""
+    cur = db_conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS provision_quality (
+            dataset TEXT NOT NULL,
+            organisation TEXT NOT NULL,
+            organisation_name TEXT,
+            has_active_endpoint BOOLEAN NOT NULL,
+            has_active_resource BOOLEAN NOT NULL,
+            owns_entities BOOLEAN NOT NULL,
+            is_designated_provider BOOLEAN NOT NULL,
+            quality TEXT,
+            entity_count BIGINT NOT NULL,
+            quality_score DOUBLE PRECISION,
+            PRIMARY KEY (dataset, organisation)
+        );
+        """
+    )
+    db_conn.commit()
+    cur.close()
+
+    yield
+
+    cur = db_conn.cursor()
+    cur.execute("TRUNCATE TABLE provision_quality;")
+    cur.execute(
+        """
+        DO $$
+        DECLARE t TEXT;
+        BEGIN
+            FOR t IN SELECT tablename FROM pg_tables
+                     WHERE schemaname = 'public'
+                       AND tablename LIKE 'provision_quality_staging_%'
+            LOOP
+                EXECUTE 'DROP TABLE IF EXISTS ' || t;
+            END LOOP;
+        END $$;
+        """
+    )
+    db_conn.commit()
+    cur.close()
+
+
+@pytest.fixture()
+def clean_dataset_quality_table(db_conn):
+    """Create the dataset_quality table before each test, truncate after."""
+    cur = db_conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS dataset_quality (
+            dataset TEXT NOT NULL,
+            authoritative_organisations INTEGER NOT NULL,
+            some_organisations INTEGER NOT NULL,
+            total_organisations INTEGER NOT NULL,
+            total_entities BIGINT NOT NULL,
+            quality_score DOUBLE PRECISION,
+            PRIMARY KEY (dataset)
+        );
+        """
+    )
+    db_conn.commit()
+    cur.close()
+
+    yield
+
+    cur = db_conn.cursor()
+    cur.execute("TRUNCATE TABLE dataset_quality;")
+    cur.execute(
+        """
+        DO $$
+        DECLARE t TEXT;
+        BEGIN
+            FOR t IN SELECT tablename FROM pg_tables
+                     WHERE schemaname = 'public'
+                       AND tablename LIKE 'dataset_quality_staging_%'
+            LOOP
+                EXECUTE 'DROP TABLE IF EXISTS ' || t;
+            END LOOP;
+        END $$;
+        """
+    )
+    db_conn.commit()
+    cur.close()

--- a/tests/integration/test_pipeline.py
+++ b/tests/integration/test_pipeline.py
@@ -23,6 +23,7 @@ from jobs.pipeline import (
     _build_dataset_quality,
     _build_organisation_quality,
     _build_provision_quality,
+    _drop_blank_organisations,
 )
 
 # -- Test data ----------------------------------------------------------------
@@ -912,3 +913,17 @@ class TestProvisionQuality:
         assert rows["1"]["organisation_entity"] == "100"
         assert rows["1"]["quality"] == "authoritative"
         assert rows["1"]["dataset"] == PQ_DATASET
+
+    def test_drop_blank_organisations(self, spark):
+        # A blank or null organisation can't key the table (organisation is a
+        # NOT NULL PK), so execute() drops these rows before writing.
+        df = spark.createDataFrame(
+            [
+                (PQ_DATASET, PQ_ADU),
+                (PQ_DATASET, ""),
+                (PQ_DATASET, None),
+            ],
+            ["dataset", "organisation"],
+        )
+        result = {r["organisation"] for r in _drop_blank_organisations(df).collect()}
+        assert result == {PQ_ADU}

--- a/tests/integration/utils/test_postgres_writer_utils.py
+++ b/tests/integration/utils/test_postgres_writer_utils.py
@@ -10,7 +10,9 @@ from datetime import date
 import pytest
 from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql.types import (
+    BooleanType,
     DateType,
+    DoubleType,
     IntegerType,
     LongType,
     StringType,
@@ -18,10 +20,12 @@ from pyspark.sql.types import (
     StructType,
 )
 
+from jobs.pipeline import DATASET_QUALITY_PG_TYPES, PROVISION_QUALITY_PG_TYPES
 from jobs.utils.postgres_writer_utils import (
     write_dataframe_to_postgres_jdbc,
     write_entity_subdivided_to_postgres,
     write_old_entity_to_postgres,
+    write_table_to_postgres,
 )
 
 
@@ -564,3 +568,138 @@ def test_write_old_entity_handles_nulls(spark, db_url, db_conn, clean_old_entity
     assert row[2] is None  # entity
     assert row[3] is None  # notes
     assert _count_tables_matching(db_conn, "old_entity_staging_%") == 0
+
+
+@pytest.mark.database
+def test_write_table_to_postgres_provision_quality(
+    spark, db_url, db_conn, clean_provision_quality_table
+):
+    """Writer fills provision_quality; nulls preserved; a second write replaces."""
+    schema = StructType(
+        [
+            StructField("dataset", StringType(), True),
+            StructField("organisation", StringType(), True),
+            StructField("organisation_name", StringType(), True),
+            StructField("has_active_endpoint", BooleanType(), True),
+            StructField("has_active_resource", BooleanType(), True),
+            StructField("owns_entities", BooleanType(), True),
+            StructField("is_designated_provider", BooleanType(), True),
+            StructField("quality", StringType(), True),
+            StructField("entity_count", LongType(), True),
+            StructField("quality_score", DoubleType(), True),
+        ]
+    )
+    rows = [
+        (
+            "conservation-area",
+            "local-authority:ADU",
+            "Adur",
+            True,
+            True,
+            True,
+            True,
+            "authoritative",
+            42,
+            None,
+        ),
+        (
+            "conservation-area",
+            "government-organisation:MHCLG",
+            None,
+            True,
+            False,
+            False,
+            False,
+            None,
+            0,
+            None,
+        ),
+    ]
+    df = spark.createDataFrame(rows, schema)
+
+    write_table_to_postgres(df, "provision_quality", PROVISION_QUALITY_PG_TYPES, db_url)
+
+    cur = db_conn.cursor()
+    cur.execute(
+        "SELECT organisation, organisation_name, has_active_endpoint, quality, "
+        "entity_count, quality_score FROM provision_quality ORDER BY organisation;"
+    )
+    result = cur.fetchall()
+    cur.close()
+    # Release the read lock (pg8000 autocommit is off) before the next write's
+    # TRUNCATE, or it blocks on this connection's open transaction.
+    db_conn.rollback()
+
+    assert len(result) == 2
+    by_org = {r[0]: r for r in result}
+    adu = by_org["local-authority:ADU"]
+    assert adu[1] == "Adur"
+    assert adu[2] is True
+    assert adu[3] == "authoritative"
+    assert adu[4] == 42
+    assert adu[5] is None
+    mhclg = by_org["government-organisation:MHCLG"]
+    assert mhclg[1] is None  # organisation_name null preserved
+    assert mhclg[3] is None  # quality null preserved
+
+    # A second write replaces (TRUNCATE + INSERT), it does not append.
+    df2 = spark.createDataFrame(
+        [
+            (
+                "green-belt",
+                "local-authority:XYZ",
+                "XYZ Council",
+                False,
+                False,
+                True,
+                False,
+                "some",
+                5,
+                None,
+            )
+        ],
+        schema,
+    )
+    write_table_to_postgres(
+        df2, "provision_quality", PROVISION_QUALITY_PG_TYPES, db_url
+    )
+    cur = db_conn.cursor()
+    cur.execute("SELECT dataset FROM provision_quality;")
+    after = cur.fetchall()
+    cur.close()
+    db_conn.rollback()
+    assert len(after) == 1
+    assert after[0][0] == "green-belt"
+    assert _count_tables_matching(db_conn, "provision_quality_staging_%") == 0
+
+
+@pytest.mark.database
+def test_write_table_to_postgres_dataset_quality_integer_counts(
+    spark, db_url, db_conn, clean_dataset_quality_table
+):
+    """Spark Long count columns land correctly in INTEGER columns."""
+    schema = StructType(
+        [
+            StructField("dataset", StringType(), True),
+            StructField("authoritative_organisations", LongType(), True),
+            StructField("some_organisations", LongType(), True),
+            StructField("total_organisations", LongType(), True),
+            StructField("total_entities", LongType(), True),
+            StructField("quality_score", DoubleType(), True),
+        ]
+    )
+    df = spark.createDataFrame(
+        [("conservation-area", 131, 175, 306, 10941, None)], schema
+    )
+    write_table_to_postgres(df, "dataset_quality", DATASET_QUALITY_PG_TYPES, db_url)
+
+    cur = db_conn.cursor()
+    cur.execute(
+        "SELECT dataset, authoritative_organisations, some_organisations, "
+        "total_organisations, total_entities FROM dataset_quality;"
+    )
+    result = cur.fetchall()
+    cur.close()
+    db_conn.rollback()
+    assert len(result) == 1
+    assert list(result[0]) == ["conservation-area", 131, 175, 306, 10941]


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Final implementation of provision-quality: the job now writes each of the three tables (`provision_quality`, `dataset_quality`, `organisation_quality`) three ways — the existing public CSVs, Delta tables to the parquet-datasets bucket, and Postgres.


## Why
We now have CSVs approved. So now to actually serve the provider breakdown on the platform, the data needs to be queryable: Delta for analysts (Athena/Databricks) and Postgres for the front-end. The Postgres tables are created by a separate Alembic migration in digital-land.info; this PR fills them.

Also added a new `_drop_blank_organisations` func which drops the few rows with a blank/null `organisation` before writing, since `organisation` is part of the NOT NULL composite primary key on `provision_quality`. If it didn't remove then the blanks would break the Postgres write.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- [Ticket Link](https://github.com/digital-land/config/issues/2778)
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

## Testing — validated end-to-end in Staging

Ran the full `provision-quality` job in staging after deploying the matching Alembic 

**Job result:** success in ~6.4 min (381s). All three output paths exercised:

- **CSV** — written to `s3://staging-collection-data/dataset/*.csv` (unchanged behaviour).
- **Delta** — written to `s3://staging-parquet-datasets/{provision_quality,dataset_quality,organisation_quality}/`.
- **Postgres** — DB URL self-resolved from Secrets Manager; the staging-table →
  `TRUNCATE`/`INSERT` swap ran against the real migration-created tables, first attempt each:
  - `provision_quality`: 3,592 rows
  - `dataset_quality`: 103 rows
  - `organisation_quality`: 505 rows

I then took a direct look at the staging db and verified directly:

| Table | Rows |
|---|---|
| provision_quality | 3592 |
| dataset_quality | 103 |
| organisation_quality | 505 |


## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?
