### PR TITLE
fix: tasks pipeline to handle differnt issue csv schemas

### DIFF
--- a/src/jobs/pipeline.py
+++ b/src/jobs/pipeline.py
@@ -24,6 +24,7 @@ from pyspark.sql import SparkSession, Window
 from pyspark.sql.functions import (
     coalesce,
     col,
+    count,
     countDistinct,
     explode,
     first,
@@ -38,7 +39,7 @@ from pyspark.sql.functions import (
 )
 
 from jobs.config.metadata import load_metadata
-from jobs.read import read_csvs_by_name, read_old_resources
+from jobs.read import read_csvs_by_name, read_issue_csvs, read_old_resources
 from jobs.transform.column_field_transformer import transform_column_field
 from jobs.transform.dataset_resource_transformer import transform_dataset_resource
 from jobs.transform.entity_transformer import transform_entity
@@ -50,7 +51,11 @@ from jobs.transform.task_transformer import (
     transform_issues_to_tasks,
     transform_log_to_tasks,
 )
-from jobs.utils.collection_paths import collection_files, collection_names
+from jobs.utils.collection_paths import (
+    collection_files,
+    collection_names,
+    issue_files_for_resources,
+)
 from jobs.utils.df_utils import count_df, normalise_column_names, show_df
 from jobs.utils.flatten_csv import flatten_json_column
 from jobs.utils.postgres_writer_utils import (
@@ -736,13 +741,15 @@ class TaskPipeline(BasePipeline):
         base = AnyPath(self.config.collection_data_path)
 
         # -- Resolve file paths ---------------------------------------------------
-        log_files = [str(p) for p in base.glob("*-collection/collection/log.csv")]
+        # Targeted listings rather than base.glob("*-collection/..."): a glob with
+        # a '/' in the pattern lists the WHOLE bucket and filters client-side.
+        collections = collection_names(base)
+        logger.info(f"TaskPipeline: Found {len(collections)} collections")
+
+        log_files = collection_files(base, collections, "log.csv")
         logger.info(f"TaskPipeline: Found {len(log_files)} log files")
 
-        issue_files = [str(p) for p in base.glob("*-collection/issue/*/*.csv")]
-        logger.info(f"TaskPipeline: Found {len(issue_files)} issue files")
-
-        source_files = [str(p) for p in base.glob("*-collection/collection/source.csv")]
+        source_files = collection_files(base, collections, "source.csv")
         logger.info(f"TaskPipeline: Found {len(source_files)} source files")
 
         log_df = spark.read.option("header", "true").csv(log_files)
@@ -790,6 +797,20 @@ class TaskPipeline(BasePipeline):
             "TaskPipeline: Active resources loaded (current resource per endpoint from log)"
         )
 
+        # -- Issue files (only for resources that survive the join below) --------
+        # The issue join is an inner join on active_df, so files for any other
+        # resource are read and then thrown away — ~26,450 files read to use
+        # ~3,000. Restricting discovery here also keeps most legacy-layout issue
+        # CSVs out of the read; read_issue_csvs handles any that remain.
+        active_resources = {
+            row["resource"] for row in active_df.select("resource").distinct().collect()
+        }
+        issue_files = issue_files_for_resources(base, collections, active_resources)
+        logger.info(
+            f"TaskPipeline: Found {len(issue_files)} issue files for "
+            f"{len(active_resources)} active resources"
+        )
+
         # -- Log tasks --------------------------------------------------------
         log_df = log_df.join(
             active_df.select("resource", "dataset", "organisation"),
@@ -812,8 +833,7 @@ class TaskPipeline(BasePipeline):
             logger.warning("TaskPipeline: No issue files found — skipping issue tasks")
             issue_tasks = None
         else:
-            issue_df = spark.read.option("header", "true").csv(issue_files)
-            issue_df = normalise_column_names(issue_df)
+            issue_df = read_issue_csvs(spark, issue_files)
             issue_df = issue_df.join(
                 active_df.select("resource", "organisation", "endpoint"),
                 on="resource",
@@ -823,12 +843,25 @@ class TaskPipeline(BasePipeline):
 
             issue_type_df = _load_issue_type_df(spark)
             issue_df = issue_df.join(issue_type_df, on="issue_type", how="left")
-            if logger.isEnabledFor(logging.DEBUG):
-                logger.debug(
-                    f"TaskPipeline: {issue_df.count()} issue rows for active resources after joining with issue type metadata"
-                )
-                logger.debug(
-                    f"TaskPipeline: {issue_df.filter(col('severity').isin('error', 'warning', 'notice')).count()} rows with severity in (error, warning, notice) — these become issue tasks"
+
+            # One pass, logged at INFO: this pipeline's failure mode was every
+            # issue row being dropped here silently, which DEBUG-only counts hid.
+            stats = issue_df.agg(
+                count("*").alias("rows"),
+                count(when(col("severity").isNotNull(), True)).alias("matched"),
+                count(
+                    when(col("severity").isin("error", "warning", "notice"), True)
+                ).alias("surviving"),
+            ).collect()[0]
+            logger.info(
+                f"TaskPipeline: {stats['rows']} issue rows for active resources, "
+                f"{stats['matched']} matched an issue-type, "
+                f"{stats['surviving']} survive the severity filter"
+            )
+            if stats["rows"] and not stats["surviving"]:
+                logger.error(
+                    "TaskPipeline: every issue row was dropped by the severity "
+                    "filter — issue CSVs are likely being misparsed"
                 )
 
             issue_tasks = transform_issues_to_tasks(issue_df)

--- a/src/jobs/transform/task_transformer.py
+++ b/src/jobs/transform/task_transformer.py
@@ -99,7 +99,10 @@ def transform_issues_to_tasks(df: DataFrame, entry_date: str = None) -> DataFram
     df = df.filter(col("severity").isin("error", "warning", "notice"))
 
     if df.rdd.isEmpty():
-        logger.info("transform_issues_to_tasks: No matching issue rows found")
+        logger.warning(
+            "transform_issues_to_tasks: no issue rows survived the severity "
+            "filter — no issue tasks will be produced"
+        )
         return None
 
     # array_distinct guards against an org appearing twice in the ';'-list,

--- a/tests/acceptance/test_run_tasks_acceptance.py
+++ b/tests/acceptance/test_run_tasks_acceptance.py
@@ -128,21 +128,41 @@ TREE_SOURCE_ROWS = [
     },
 ]
 
-ISSUE_COLUMNS = ["resource", "dataset", "field", "issue-type"]
+ISSUE_COLUMNS = [
+    "dataset",
+    "resource",
+    "line-number",
+    "entry-number",
+    "field",
+    "entity",
+    "issue-type",
+    "value",
+    "message",
+]
 
 # Two rows for the same issue — should group into one task with count=2
 CA_ISSUE_ROWS = [
     {
-        "resource": "resource-ca-aaa",
         "dataset": "conservation-area",
+        "resource": "resource-ca-aaa",
+        "line-number": "1",
+        "entry-number": "1",
         "field": "geometry",
+        "entity": "4400001",
         "issue-type": "invalid-geometry",
+        "value": "POLYGON((0 0))",
+        "message": "invalid geometry",
     },
     {
-        "resource": "resource-ca-aaa",
         "dataset": "conservation-area",
+        "resource": "resource-ca-aaa",
+        "line-number": "2",
+        "entry-number": "2",
         "field": "geometry",
+        "entity": "4400002",
         "issue-type": "invalid-geometry",
+        "value": "POLYGON((1 1))",
+        "message": "invalid geometry",
     },
 ]
 

--- a/tests/integration/test_pipeline.py
+++ b/tests/integration/test_pipeline.py
@@ -603,14 +603,28 @@ class TestTaskPipeline:
             os.path.join(
                 base, "test-collection", "issue", "dataset-a", "resource-aaa.csv"
             ),
-            ["resource", "issue_type", "field", "value", "dataset"],
+            [
+                "dataset",
+                "resource",
+                "line-number",
+                "entry-number",
+                "field",
+                "entity",
+                "issue-type",
+                "value",
+                "message",
+            ],
             [
                 {
-                    "resource": "resource-aaa",
-                    "issue_type": "invalid-geometry",
-                    "field": "geometry",
-                    "value": "POLYGON((0 0))",
                     "dataset": "dataset-a",
+                    "resource": "resource-aaa",
+                    "line-number": "1",
+                    "entry-number": "1",
+                    "field": "geometry",
+                    "entity": "4400001",
+                    "issue-type": "invalid-geometry",
+                    "value": "POLYGON((0 0))",
+                    "message": "invalid",
                 }
             ],
         )
@@ -638,6 +652,114 @@ class TestTaskPipeline:
         assert len(references) == len(
             set(references)
         ), f"{len(references) - len(set(references))} duplicate references found"
+
+    def test_mixed_issue_csv_layouts_all_produce_tasks(self, spark, tmp_path, mocker):
+        """Issue CSVs exist in 7-, 8- and 9-column layouts. All three must
+        produce tasks — a single positional multi-file read applies one file's
+        header to the others and silently drops the mismatched ones."""
+        base = str(tmp_path)
+        parquet_base = os.path.join(base, "parquet-output/")
+
+        _write_csv(
+            os.path.join(base, "test-collection", "collection", "log.csv"),
+            ["endpoint", "resource", "status", "exception", "entry-date"],
+            [
+                {
+                    "endpoint": f"http://endpoint-{n}",
+                    "resource": f"resource-{n}",
+                    "status": "200",
+                    "exception": "",
+                    "entry-date": "2026-01-01",
+                }
+                for n in ("7", "8", "9")
+            ],
+        )
+
+        issue_dir = os.path.join(base, "test-collection", "issue", "dataset-a")
+        common = {
+            "dataset": "dataset-a",
+            "line-number": "1",
+            "entry-number": "1",
+            "field": "geometry",
+            "issue-type": "OSGB flipped",
+            "value": "POLYGON((0 0))",
+        }
+
+        _write_csv(
+            os.path.join(issue_dir, "resource-7.csv"),
+            [
+                "dataset",
+                "resource",
+                "line-number",
+                "entry-number",
+                "field",
+                "issue-type",
+                "value",
+            ],
+            [{**common, "resource": "resource-7"}],
+        )
+        _write_csv(
+            os.path.join(issue_dir, "resource-8.csv"),
+            [
+                "dataset",
+                "resource",
+                "line-number",
+                "entry-number",
+                "field",
+                "issue-type",
+                "value",
+                "message",
+            ],
+            [{**common, "resource": "resource-8", "message": "flipped"}],
+        )
+        _write_csv(
+            os.path.join(issue_dir, "resource-9.csv"),
+            [
+                "dataset",
+                "resource",
+                "line-number",
+                "entry-number",
+                "field",
+                "entity",
+                "issue-type",
+                "value",
+                "message",
+            ],
+            [
+                {
+                    **common,
+                    "resource": "resource-9",
+                    "entity": "4400001",
+                    "message": "flipped",
+                }
+            ],
+        )
+
+        mocker.patch(
+            "jobs.pipeline._load_issue_type_df",
+            return_value=spark.createDataFrame(
+                [("OSGB flipped", "warning", "external")],
+                ["issue_type", "severity", "responsibility"],
+            ),
+        )
+
+        config = PipelineConfig(
+            spark=spark,
+            dataset="",
+            env="local",
+            collection_data_path=f"{base}/",
+            parquet_datasets_path=parquet_base,
+        )
+
+        TaskPipeline(config).run()
+
+        tasks_df = spark.read.format("delta").load(os.path.join(parquet_base, "task"))
+        issue_tasks = tasks_df.filter(tasks_df.task_source == "issue")
+        assert {row["resource"] for row in issue_tasks.collect()} == {
+            "resource-7",
+            "resource-8",
+            "resource-9",
+        }
 
 
 class TestBackfillDatasetFromSource:


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Issue file discovery is now driven by the active resources rather than a glob over the whole s3 bucket. `TaskPipeline` lists the collections once and builds the `log.csv`, `source.csv` and issue paths directly, so it reads roughly 3,000 issue CSVs instead of all 26,450 — the rest were read and then discarded by the inner join against active resources anyway. 

Issue CSVs are now read through `read_issue_csvs`, which aligns each file on its own header rather than applying one file's header positionally to all of them, so the 7-, 8- and 9-column layouts all parse correctly. 

## Why

Production is missing most issue-derived tasks — around 5% coverage for brownfield-land, 10% for conservation-area, 32% for article-4-direction-area — so LPAs with live data problems see nothing on the LPA Dashboard. Issue CSVs exist in three layouts because an `entity` column was added at position 6, shifting `issue-type` from index 5 to 6. Spark infers the schema from one file and applies it positionally to the rest, so `issue_type` receives the entity number, the join against the issue-type spec returns a null severity, and every row is dropped by the severity filter with no error and exit code 0. 


## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- [Ticket Link](https://github.com/digital-land/config/issues/2892)
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

I have deployed to development and ran the tasks pipeline: 

No errors
Ran much faster
increased the number of issues found slightly (true test of if the fix works will be in PROD)

New logging line: 

`[2026-08-13 10:57:34,859] INFO - jobs.pipeline:809 - TaskPipeline: Found 2820 issue files for 2837 active resources`
Should enable us to track this kind of error easier in future.



## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?
