### PR TITLE
feat: make tasks from expectations

### DIFF
--- a/src/jobs/pipeline/task.py
+++ b/src/jobs/pipeline/task.py
@@ -7,17 +7,28 @@ from functools import reduce
 
 from cloudpathlib import AnyPath
 from pyspark.sql import Window
-from pyspark.sql.functions import col, count, explode, lit, row_number, split, when
+from pyspark.sql.functions import (
+    col,
+    count,
+    explode,
+    lit,
+    lower,
+    row_number,
+    split,
+    when,
+)
 
 from jobs.pipeline.base import BasePipeline
 from jobs.read import read_issue_csvs
 from jobs.transform.task_transformer import (
+    transform_expectations_to_tasks,
     transform_issues_to_tasks,
     transform_log_to_tasks,
 )
 from jobs.utils.collection_paths import (
     collection_files,
     collection_names,
+    expectation_files,
     issue_files_for_resources,
 )
 from jobs.utils.df_utils import normalise_column_names
@@ -246,8 +257,63 @@ class TaskPipeline(BasePipeline):
 
             issue_tasks = transform_issues_to_tasks(issue_df)
 
+        # -- Expectation tasks -------------------------------------------------
+        # Expectations run against the assembled dataset, so unlike issues they
+        # have no resource to join on and are not filtered by active resources.
+        exp_files = expectation_files(base)
+        logger.info(f"TaskPipeline: Found {len(exp_files)} expectation files")
+
+        if not exp_files:
+            logger.warning(
+                "TaskPipeline: No expectation files found — skipping expectation tasks"
+            )
+            expectation_tasks = None
+        else:
+            expectation_df = spark.read.parquet(*exp_files)
+
+            org_path = str(
+                base / "organisation-collection" / "dataset" / "organisation.csv"
+            )
+            org_df = normalise_column_names(
+                spark.read.option("header", "true").csv(org_path)
+            ).select(
+                col("organisation"),
+                col("entity").alias("organisation_entity"),
+            )
+
+            # Same shape of guard as the issue path above: the failure mode
+            # here is every row being dropped, which produces no tasks and no
+            # error, so the counts are logged rather than left to DEBUG.
+            stats = expectation_df.agg(
+                count("*").alias("rows"),
+                count(when(lower(col("passed").cast("string")) == "false", True)).alias(
+                    "failed"
+                ),
+                count(
+                    when(
+                        (lower(col("passed").cast("string")) == "false")
+                        & col("severity").isin("error", "warning", "notice"),
+                        True,
+                    )
+                ).alias("surviving"),
+            ).collect()[0]
+            logger.info(
+                f"TaskPipeline: {stats['rows']} expectation rows, "
+                f"{stats['failed']} failed, "
+                f"{stats['surviving']} survive the severity filter"
+            )
+            if stats["rows"] and not stats["surviving"]:
+                logger.error(
+                    "TaskPipeline: every expectation row was dropped by the "
+                    "filters — check `passed` and `severity` values"
+                )
+
+            expectation_tasks = transform_expectations_to_tasks(expectation_df, org_df)
+
         # -- Union and write --------------------------------------------------
-        frames = [df for df in [log_tasks, issue_tasks] if df is not None]
+        frames = [
+            df for df in [log_tasks, issue_tasks, expectation_tasks] if df is not None
+        ]
 
         if not frames:
             logger.warning("TaskPipeline: No tasks generated — nothing to write")

--- a/src/jobs/transform/task_transformer.py
+++ b/src/jobs/transform/task_transformer.py
@@ -12,12 +12,23 @@ from pyspark.sql.functions import (
     count,
     explode,
     first,
+    from_json,
     lit,
+    lower,
     sha2,
+    size,
     split,
     struct,
     substring,
+    sum as spark_sum,
     to_json,
+)
+from pyspark.sql.types import (
+    ArrayType,
+    LongType,
+    StringType,
+    StructField,
+    StructType,
 )
 
 logger = logging.getLogger(__name__)
@@ -31,6 +42,28 @@ logger = logging.getLogger(__name__)
 # in the reference hash. digital-land-python's task.py still uses
 # severity=error/responsibility=external and a hash without organisation —
 # bring these back in sync if/when that implementation is updated to match.
+
+
+# Only the keys the bridge needs. from_json ignores everything else in the blob,
+# so checks can keep their own extra keys without this having to change.
+_EXPECTATION_DETAILS_SCHEMA = StructType(
+    [
+        StructField("error", StringType(), True),
+        StructField("field", StringType(), True),
+        StructField(
+            "failures",
+            ArrayType(
+                StructType(
+                    [
+                        StructField("organisation_entity", StringType(), True),
+                        StructField("count", LongType(), True),
+                    ]
+                )
+            ),
+            True,
+        ),
+    ]
+)
 
 
 def transform_log_to_tasks(df: DataFrame, entry_date: str = None) -> DataFrame:
@@ -132,6 +165,121 @@ def transform_issues_to_tasks(df: DataFrame, entry_date: str = None) -> DataFram
             ),
         )
         .withColumn("task_source", lit("issue"))
+        .withColumn("entry_date", lit(entry_date))
+    )
+
+    grouped = _add_reference(grouped)
+
+    return grouped.select(
+        col("dataset"),
+        col("organisation"),
+        col("endpoint"),
+        col("resource"),
+        col("details"),
+        col("severity"),
+        col("responsibility"),
+        col("task_source"),
+        col("entry_date"),
+        col("reference"),
+    )
+
+
+def transform_expectations_to_tasks(
+    df: DataFrame, org_df: DataFrame, entry_date: str = None
+) -> DataFrame:
+    """
+    Transform an expectation DataFrame into task rows.
+
+    Expects df to be the expectation parquet — one row per (dataset, check),
+    with `details` as a JSON string. org_df maps organisation_entity to the
+    organisation curie the task schema uses, and must carry both columns.
+
+    Unlike issues, expectations are computed against the assembled dataset, so
+    there is no resource or endpoint to attribute them to.
+    """
+    entry_date = entry_date or str(date.today())
+    logger.info("transform_expectations_to_tasks: Starting")
+
+    # `passed` is written as the string "True"/"False", not a boolean. Casting
+    # and comparing as a string works for either shape, so this does not depend
+    # on the writer's choice of type. (Spark coerces a bare `== False` correctly
+    # too, but this avoids the E712 lint suppression that would need.)
+    df = df.filter(lower(col("passed").cast("string")) == "false").filter(
+        col("severity").isin("error", "warning", "notice")
+    )
+
+    parsed = df.withColumn(
+        "_details", from_json(col("details"), _EXPECTATION_DETAILS_SCHEMA)
+    )
+
+    # A check that errored found nothing. It used to report an empty details
+    # dict; since digital-land-python#587 it reports {"error": ...}, so both
+    # shapes have to be dropped here.
+    parsed = parsed.filter(col("_details").isNotNull() & col("_details.error").isNull())
+
+    # No failures means nothing attributable to an organisation: either a check
+    # predating the details standardisation, or duplicate_geometry_check where an
+    # organisation's polygons only touch each other. Neither is a task.
+    parsed = parsed.filter(
+        col("_details.failures").isNotNull() & (size(col("_details.failures")) > 0)
+    )
+
+    if parsed.rdd.isEmpty():
+        logger.warning(
+            "transform_expectations_to_tasks: no expectation rows survived the "
+            "filters — no expectation tasks will be produced"
+        )
+        return None
+
+    exploded = (
+        parsed.withColumn("_failure", explode(col("_details.failures")))
+        .withColumn(
+            "organisation_entity", col("_failure.organisation_entity").cast("string")
+        )
+        .withColumn("_failure_count", col("_failure.count"))
+        .withColumn("field", coalesce(col("_details.field"), lit("")))
+    )
+
+    grouped = exploded.groupBy("dataset", "organisation_entity", "operation").agg(
+        # Where a check supplies its own count, sum it — a duplicate-name failure
+        # carries the number of entities sharing that name. Where it does not,
+        # each failure is one offending entity, hence the 1.
+        spark_sum(coalesce(col("_failure_count"), lit(1))).alias("count"),
+        # How many failure records the organisation has, e.g. how many distinct
+        # names are duplicated as against how many entities that affects.
+        count("*").alias("groups"),
+        first("severity").alias("severity"),
+        first("responsibility").alias("responsibility"),
+        first("field").alias("field"),
+    )
+
+    # organisation_entity is an entity number; the task schema wants the curie.
+    # Inner join so a failure naming an unknown organisation is dropped rather
+    # than becoming an unattributed task no one can see.
+    org_df = org_df.select(
+        col("organisation_entity").cast("string").alias("organisation_entity"),
+        col("organisation"),
+    )
+    grouped = grouped.join(org_df, on="organisation_entity", how="inner")
+
+    grouped = (
+        grouped.withColumn(
+            "details",
+            to_json(
+                struct(
+                    # `operation`, deliberately not `issue_type`: submit's task
+                    # list only renders tasks whose details carry issue_type and
+                    # field, so this keeps expectation tasks out of that path.
+                    col("operation"),
+                    col("count").cast("int").alias("count"),
+                    col("groups").cast("int").alias("groups"),
+                    col("field"),
+                )
+            ),
+        )
+        .withColumn("endpoint", lit(""))
+        .withColumn("resource", lit(""))
+        .withColumn("task_source", lit("expectation"))
         .withColumn("entry_date", lit(entry_date))
     )
 

--- a/src/jobs/utils/collection_paths.py
+++ b/src/jobs/utils/collection_paths.py
@@ -84,3 +84,35 @@ def issue_files_for_resources(
                 continue
             files.extend(str(p) for p in dataset_dir.iterdir() if p.stem in resources)
     return files
+
+
+def expectation_files(base: AnyPath) -> list[str]:
+    """Paths to the per-dataset expectation parquet files.
+
+    These sit at the bucket root under a bare `log/`, not under a
+    {collection}-collection prefix, because OUTPUT_LOG_DIR is `log/` and
+    makerules syncs it straight to the root.
+
+    The layout is hive-style (`dataset=<name>/`), but the files are listed
+    rather than handed to Spark as a partitioned directory: the parquet
+    already carries its own `dataset` column, so partition discovery would
+    produce a second column of the same name and collide. Reading the files
+    directly and using the in-file column avoids the question.
+
+    Args:
+        base: Root of the collection-data bucket
+
+    Returns:
+        Paths as strings, ready to hand to spark.read
+    """
+    expectation_dir = base / "log" / "expectation"
+    if not expectation_dir.exists():
+        logger.warning(f"expectation_files: {expectation_dir} does not exist")
+        return []
+
+    files = []
+    for dataset_dir in expectation_dir.iterdir():
+        if not dataset_dir.is_dir():
+            continue
+        files.extend(str(p) for p in dataset_dir.iterdir() if p.suffix == ".parquet")
+    return files

--- a/tests/integration/transform/test_task_transformer.py
+++ b/tests/integration/transform/test_task_transformer.py
@@ -3,13 +3,14 @@ Integration tests for transform_log_to_tasks and transform_issues_to_tasks.
 
 Uses a real Spark session. Tests the full transformer functions with real
 DataFrames including filtering, grouping, and reference hash generation.
-For tests of the underlying UDF functions without Spark, see:
+To see the tests of the underlying UDF functions without Spark, see:
 tests/unit/transform/test_task_transformer.py
 """
 
 import json
 
 from jobs.transform.task_transformer import (
+    transform_expectations_to_tasks,
     transform_issues_to_tasks,
     transform_log_to_tasks,
 )
@@ -689,3 +690,328 @@ class TestTransformIssuesToTasks:
         result = transform_issues_to_tasks(df)
         references = [row["reference"] for row in result.collect()]
         assert len(references) == len(set(references))
+
+
+EXPECTATION_COLUMNS = [
+    "dataset",
+    "organisation",
+    "operation",
+    "passed",
+    "severity",
+    "responsibility",
+    "details",
+]
+
+ORG_COLUMNS = ["organisation_entity", "organisation"]
+
+
+def _details(failures=None, field="name", error=None):
+    """Build a details JSON blob in the shape the expectation parquet uses."""
+    blob = {"actual": len(failures or []), "expected": 0}
+    if field is not None:
+        blob["field"] = field
+    if error is not None:
+        blob["error"] = error
+    if failures is not None:
+        blob["failures"] = failures
+    return json.dumps(blob)
+
+
+def _org_df(spark):
+    return _build_df(
+        spark,
+        [("366", "local-authority:BRO"), ("202", "local-authority:LBH")],
+        ORG_COLUMNS,
+    )
+
+
+def _expectation_row(
+    operation="duplicate_name_check",
+    passed="False",
+    severity="warning",
+    details=None,
+    dataset="dataset-a",
+):
+    # top-level organisation is blank on dataset-wide checks; attribution lives
+    # inside details.failures
+    return (
+        dataset,
+        "",
+        operation,
+        passed,
+        severity,
+        "external",
+        details if details is not None else _details([{"organisation_entity": "366"}]),
+    )
+
+
+class TestTransformExpectationsToTasks:
+
+    def test_excludes_rows_that_passed(self, spark):
+        """`passed` is written as a string, so the filter casts rather than
+        comparing to a bool. Either shape yields the same rows."""
+        df = _build_df(
+            spark,
+            [
+                _expectation_row(passed="False"),
+                _expectation_row(passed="True"),
+            ],
+            EXPECTATION_COLUMNS,
+        )
+        result = transform_expectations_to_tasks(df, _org_df(spark))
+        assert result is not None
+        assert result.count() == 1
+
+    def test_excludes_info_severity_rows(self, spark):
+        df = _build_df(
+            spark,
+            [
+                _expectation_row(severity="warning"),
+                _expectation_row(severity="info", operation="other_check"),
+            ],
+            EXPECTATION_COLUMNS,
+        )
+        result = transform_expectations_to_tasks(df, _org_df(spark))
+        assert result.count() == 1
+
+    def test_includes_internal_responsibility_rows(self, spark):
+        """Control A copies the issue filter, which has no responsibility
+        filter — duplicate_geometry_check is internal and still produces tasks."""
+        row = list(_expectation_row(operation="duplicate_geometry_check"))
+        row[5] = "internal"
+        df = _build_df(spark, [tuple(row)], EXPECTATION_COLUMNS)
+        result = transform_expectations_to_tasks(df, _org_df(spark))
+        assert result.count() == 1
+        assert result.collect()[0]["responsibility"] == "internal"
+
+    def test_drops_rows_whose_check_errored(self, spark):
+        """Since digital-land-python#587 a failed geometry fetch reports
+        {"error": ...} rather than an empty details dict."""
+        df = _build_df(
+            spark,
+            [
+                _expectation_row(
+                    operation="count_lpa_boundary",
+                    details=_details(error="404 Client Error", field=None),
+                ),
+                _expectation_row(),
+            ],
+            EXPECTATION_COLUMNS,
+        )
+        result = transform_expectations_to_tasks(df, _org_df(spark))
+        assert result.count() == 1
+        assert json.loads(result.collect()[0]["details"])["operation"] == (
+            "duplicate_name_check"
+        )
+
+    def test_error_takes_precedence_over_failures(self, spark):
+        """A check that errored is dropped even if it somehow reported
+        failures — its findings cannot be trusted. Without this guard the
+        no-failures filter alone would let such a row through."""
+        df = _build_df(
+            spark,
+            [
+                _expectation_row(
+                    operation="count_lpa_boundary",
+                    details=json.dumps(
+                        {
+                            "error": "404 Client Error",
+                            "failures": [{"organisation_entity": "366", "count": 3}],
+                        }
+                    ),
+                ),
+                _expectation_row(),
+            ],
+            EXPECTATION_COLUMNS,
+        )
+        result = transform_expectations_to_tasks(df, _org_df(spark))
+        assert result.count() == 1
+        assert json.loads(result.collect()[0]["details"])["operation"] == (
+            "duplicate_name_check"
+        )
+
+    def test_drops_rows_with_no_failures(self, spark):
+        """No failures means nothing attributable to an organisation."""
+        df = _build_df(
+            spark,
+            [
+                _expectation_row(details=_details(failures=[])),
+                _expectation_row(details=_details(failures=None, field=None)),
+            ],
+            EXPECTATION_COLUMNS,
+        )
+        result = transform_expectations_to_tasks(df, _org_df(spark))
+        assert result is None
+
+    def test_returns_none_when_no_matching_rows(self, spark):
+        df = _build_df(spark, [_expectation_row(passed="True")], EXPECTATION_COLUMNS)
+        assert transform_expectations_to_tasks(df, _org_df(spark)) is None
+
+    def test_sums_per_failure_count_where_present(self, spark):
+        """A duplicate-name failure carries the number of entities sharing the
+        name, so count sums them while groups counts the failures."""
+        df = _build_df(
+            spark,
+            [
+                _expectation_row(
+                    details=_details(
+                        [
+                            {"organisation_entity": "366", "count": 5},
+                            {"organisation_entity": "366", "count": 4},
+                        ]
+                    )
+                )
+            ],
+            EXPECTATION_COLUMNS,
+        )
+        details = json.loads(
+            transform_expectations_to_tasks(df, _org_df(spark)).collect()[0]["details"]
+        )
+        assert details["count"] == 9
+        assert details["groups"] == 2
+
+    def test_counts_failures_where_no_per_failure_count(self, spark):
+        """name_is_a_code_check emits one failure per entity with no count, so
+        count and groups come out equal — which reads as 'no grouping'."""
+        df = _build_df(
+            spark,
+            [
+                _expectation_row(
+                    operation="name_is_a_code_check",
+                    details=_details(
+                        [
+                            {"organisation_entity": "366", "entity": 1},
+                            {"organisation_entity": "366", "entity": 2},
+                            {"organisation_entity": "366", "entity": 3},
+                        ]
+                    ),
+                )
+            ],
+            EXPECTATION_COLUMNS,
+        )
+        details = json.loads(
+            transform_expectations_to_tasks(df, _org_df(spark)).collect()[0]["details"]
+        )
+        assert details["count"] == 3
+        assert details["groups"] == 3
+
+    def test_groups_per_organisation_and_operation(self, spark):
+        df = _build_df(
+            spark,
+            [
+                _expectation_row(
+                    details=_details(
+                        [
+                            {"organisation_entity": "366", "count": 2},
+                            {"organisation_entity": "202", "count": 7},
+                        ]
+                    )
+                ),
+                _expectation_row(
+                    operation="name_is_a_code_check",
+                    details=_details([{"organisation_entity": "366"}]),
+                ),
+            ],
+            EXPECTATION_COLUMNS,
+        )
+        result = transform_expectations_to_tasks(df, _org_df(spark))
+        assert result.count() == 3
+        by_org = {
+            (r["organisation"], json.loads(r["details"])["operation"]): json.loads(
+                r["details"]
+            )["count"]
+            for r in result.collect()
+        }
+        assert by_org[("local-authority:BRO", "duplicate_name_check")] == 2
+        assert by_org[("local-authority:LBH", "duplicate_name_check")] == 7
+        assert by_org[("local-authority:BRO", "name_is_a_code_check")] == 1
+
+    def test_resolves_organisation_entity_to_curie(self, spark):
+        df = _build_df(spark, [_expectation_row()], EXPECTATION_COLUMNS)
+        result = transform_expectations_to_tasks(df, _org_df(spark))
+        assert result.collect()[0]["organisation"] == "local-authority:BRO"
+
+    def test_drops_failures_with_an_unknown_organisation(self, spark):
+        """Inner join: an unresolvable entity is dropped rather than becoming an
+        unattributed task no LPA can see."""
+        df = _build_df(
+            spark,
+            [
+                _expectation_row(
+                    details=_details(
+                        [
+                            {"organisation_entity": "366", "count": 2},
+                            {"organisation_entity": "999999", "count": 3},
+                        ]
+                    )
+                )
+            ],
+            EXPECTATION_COLUMNS,
+        )
+        result = transform_expectations_to_tasks(df, _org_df(spark))
+        assert result.count() == 1
+        assert result.collect()[0]["organisation"] == "local-authority:BRO"
+
+    def test_output_has_correct_columns(self, spark):
+        df = _build_df(spark, [_expectation_row()], EXPECTATION_COLUMNS)
+        result = transform_expectations_to_tasks(df, _org_df(spark))
+        assert result.columns == [
+            "dataset",
+            "organisation",
+            "endpoint",
+            "resource",
+            "details",
+            "severity",
+            "responsibility",
+            "task_source",
+            "entry_date",
+            "reference",
+        ]
+
+    def test_task_source_is_expectation(self, spark):
+        df = _build_df(spark, [_expectation_row()], EXPECTATION_COLUMNS)
+        result = transform_expectations_to_tasks(df, _org_df(spark))
+        assert result.collect()[0]["task_source"] == "expectation"
+
+    def test_endpoint_and_resource_are_blank(self, spark):
+        """Expectations run on the assembled dataset, so there is no endpoint or
+        resource to attribute them to."""
+        df = _build_df(spark, [_expectation_row()], EXPECTATION_COLUMNS)
+        row = transform_expectations_to_tasks(df, _org_df(spark)).collect()[0]
+        assert row["endpoint"] == ""
+        assert row["resource"] == ""
+
+    def test_details_uses_operation_not_issue_type(self, spark):
+        """submit's task list only renders tasks whose details carry issue_type
+        and field, so keying on operation keeps these out of that path."""
+        df = _build_df(spark, [_expectation_row()], EXPECTATION_COLUMNS)
+        details = json.loads(
+            transform_expectations_to_tasks(df, _org_df(spark)).collect()[0]["details"]
+        )
+        assert details["operation"] == "duplicate_name_check"
+        assert "issue_type" not in details
+
+    def test_reference_is_16_chars(self, spark):
+        df = _build_df(spark, [_expectation_row()], EXPECTATION_COLUMNS)
+        result = transform_expectations_to_tasks(df, _org_df(spark))
+        assert len(result.collect()[0]["reference"]) == 16
+
+    def test_references_are_unique(self, spark):
+        df = _build_df(
+            spark,
+            [
+                _expectation_row(
+                    details=_details(
+                        [
+                            {"organisation_entity": "366", "count": 2},
+                            {"organisation_entity": "202", "count": 7},
+                        ]
+                    )
+                ),
+                _expectation_row(operation="name_is_a_code_check"),
+            ],
+            EXPECTATION_COLUMNS,
+        )
+        result = transform_expectations_to_tasks(df, _org_df(spark))
+        refs = [r["reference"] for r in result.collect()]
+        assert len(refs) == len(set(refs))


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

`TaskPipeline` now generates tasks from dataset expectations, as a third source alongside logs and issues. It reads the per-dataset expectation parquets, keeps failed checks at error/warning/notice severity, resolves each finding's `organisation_entity` to an organisation, and emits one task per (dataset, organisation, operation) carrying both the number of entities affected and the number of findings.

## Why

Expectation results currently stop at the expectation parquet — nothing carries them into the task table, so an LPA never sees them. This is the bridge that makes the #598 name checks visible, and the last piece before the front end can render them.

Two gates keep these tasks off dashboards until that front-end work is ready: the API already filters on `task_source`, and the task `details` are keyed on `operation` rather than `issue_type`, which submit's task list requires before it will render a task. Output is also limited until digital-land/digital-land-python#587 merges — three of the checks don't yet report per-organisation findings, so they produce no tasks and are skipped.


## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- [Ticket Link](https://github.com/digital-land/config/issues/2912)
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?
